### PR TITLE
overhaul field type deduction to no longer require default values except for enumerations

### DIFF
--- a/src/main/scala/org/squeryl/annotations/ColumnBase.java
+++ b/src/main/scala/org/squeryl/annotations/ColumnBase.java
@@ -42,7 +42,4 @@ public @interface ColumnBase {
     int scale() default -1;
 
     String dbType() default "";
-
-    Class<?> optionType() default Object.class;
-
 }

--- a/src/main/scala/org/squeryl/customtypes/CustomTypesMode.scala
+++ b/src/main/scala/org/squeryl/customtypes/CustomTypesMode.scala
@@ -21,7 +21,7 @@ import java.util.Date
 import org.squeryl.dsl.ast.{SelectElement, SelectElementReference, ConstantExpressionNode}
 import org.squeryl.dsl._
 
-trait CustomType extends Product1[Any] {
+trait CustomType[T] extends Product1[T] {
   def canEqual(a:Any) = false
 }
 
@@ -236,38 +236,38 @@ trait CustomTypesMode extends QueryDsl {
 object CustomTypesMode extends CustomTypesMode 
 
 
-class ByteField(val value: Byte) extends CustomType {
-  def _1: Any = value
+class ByteField(val value: Byte) extends CustomType[Byte] {
+  def _1: Byte = value
 }
 
-class IntField(val value: Int) extends CustomType {
-  def _1: Any = value
+class IntField(val value: Int) extends CustomType[Int] {
+  def _1: Int = value
 }
 
-class StringField(val value: String) extends CustomType {
-  def _1: Any = value
+class StringField(val value: String) extends CustomType[String] {
+  def _1: String = value
 }
 
-class DoubleField(val value: Double) extends CustomType {
-  def _1: Any = value
+class DoubleField(val value: Double) extends CustomType[Double] {
+  def _1: Double = value
 }
 
-class BigDecimalField(val value: BigDecimal) extends CustomType {
-  def _1: Any = value
+class BigDecimalField(val value: BigDecimal) extends CustomType[BigDecimal] {
+  def _1: BigDecimal = value
 }
 
-class FloatField(val value: Float) extends CustomType {
-  def _1: Any = value
+class FloatField(val value: Float) extends CustomType[Float] {
+  def _1: Float = value
 }
 
-class LongField(val value: Long) extends CustomType {
-  def _1: Any = value
+class LongField(val value: Long) extends CustomType[Long] {
+  def _1: Long = value
 }
 
-class BooleanField(val value: Boolean) extends CustomType {
-  def _1: Any = value
+class BooleanField(val value: Boolean) extends CustomType[Boolean] {
+  def _1: Boolean = value
 }
 
-class DateField(val value: Date) extends CustomType {
-  def _1: Any = value
+class DateField(val value: Date) extends CustomType[Date] {
+  def _1: Date = value
 }

--- a/src/test/scala/org/squeryl/tests/AnnotationTests.scala
+++ b/src/test/scala/org/squeryl/tests/AnnotationTests.scala
@@ -23,15 +23,7 @@ import java.util.Date
 @Row("T_TOASTER")
 class Toaster(
 
-  @Column(optionType=classOf[Int])
   var yearOfManufacture: Option[Int],
-
-// TODO: uncomment when scalac bug #3003 is resolved
-//  @Column(optionType=classOf[String], length=25)
-//  var countryOfOrigin: Option[String],
-
-//  @Column(name="dateOfPurchase", optionType=classOf[java.util.Date])
-//  var dateOfPurchase: Option[java.util.Date]
 
   @Column(length=25)
   var countryOfOrigin: String,
@@ -39,7 +31,7 @@ class Toaster(
   @Column(name="BRAND_NAME", length=32)
   var brandName: String) {
 
-  @Column(name="WEIGHT", optionType=classOf[Float])
+  @Column(name="WEIGHT")
   var weightInGrams: Option[String] = None
 
   @Column("Zozo12")
@@ -65,10 +57,9 @@ class AnnotationTests {
 
 
   class C(
-    @Column(optionType=classOf[Long]) var j: Option[Long],
-    @Column(optionType=classOf[java.lang.String]) var k: Option[String]) (
+    var j: Option[Long],
+    var k: Option[String]) (
   
-    @Column(optionType=classOf[Int])
     var i:Option[Int]
   )
 
@@ -122,24 +113,4 @@ class AnnotationTests {
 
     println('testMetaData + " passed.")
   }
-
-  /**
-   * There has been a Scala bug with obtaining a Class[_] member in annotations,
-   * if this test fails, it means that Scala has regressed TODO: file a bug 
-   */
-  def scalaReflectionTests = {
-    val colAnotations =
-      classOf[C].getDeclaredFields.toList.sortBy(f => f.getName).map(f => f.getAnnotations.toList).flatten
-
-    val c = colAnotations.size 
-    assert(c == 3, "class " + classOf[C].getName + " has 3 field annotations of type Column that have failed to be reflected, " + c + " were reflected")
-
-    val t1 = colAnotations.apply(0).asInstanceOf[Column].optionType
-    val t2 = colAnotations.apply(1).asInstanceOf[Column].optionType
-    val t3 = colAnotations.apply(2).asInstanceOf[Column].optionType
-
-    assert(classOf[Int].isAssignableFrom(t1), "expected classOf[Int], got " + t1.getName)
-    assert(classOf[Long].isAssignableFrom(t2), "expected classOf[Long], got " + t2.getName)
-    assert(classOf[String].isAssignableFrom(t3), "expected classOf[String], got " + t3.getName)
-  }  
 }


### PR DESCRIPTION
_phew_ ended up taking me much more than I thought, mostly because deduction of custom types turned out to be much harder.

quick tour of the changes:
- added a new function `deduceFieldTypeAndOption` to `FieldMetaData` that encapsulates the main work of following the reflective types around to get the refined types. understands `PrimitiveType`, `Option[PrimitiveType]`, `CustomType <: Product1[PrimitiveType]`, and `Option[CustomType <: Product1[PrimitiveType]]`
- modified `FieldMetaData.build` and other places to use this common function to deduce/validate a field type
- mostly removed uses of `FieldMetaData.createDefaultValue`
- `CustomType` becomes `CustomType[T]`, otherwise `CustomType <: Product1[Any]` which won't work
- `optionType` removed from `@ColumnBase` because the new code does not look at it
- this change makes consistent where `Option` types are supported. for example, they were not supported for classes with no zero-arg constructor and now they are
