### PR TITLE
parentQueryable returns an option so isDirectOuterReference will work if 

### DIFF
--- a/src/main/scala/org/squeryl/dsl/ast/SelectElement.scala
+++ b/src/main/scala/org/squeryl/dsl/ast/SelectElement.scala
@@ -55,7 +55,7 @@ trait SelectElement extends ExpressionNode {
    */  
   def origin: QueryableExpressionNode
 
-  def parentQueryable = parent.get.asInstanceOf[QueryableExpressionNode]  
+  def parentQueryable = parent.map{_.asInstanceOf[QueryableExpressionNode]}
 
   def resultSetMapper: ResultSetMapper
 
@@ -270,7 +270,7 @@ class SelectElementReference[A]
       selectElement
     else {
       val us = this._useSite
-      if(selectElement.parentQueryable == us)
+      if(selectElement.parentQueryable == Some(us))
         selectElement
       else {
         val ese = new ExportedSelectElement(this.selectElement)
@@ -352,7 +352,7 @@ class ExportedSelectElement
 
   def needsOuterScope:Boolean = innerTarget.isEmpty && outerTarget.isEmpty && ! isDirectOuterReference
 
-  private def isDirectOuterReference: Boolean = outerScopes.exists((outer) => outer == selectElement.parentQueryable)
+  private def isDirectOuterReference: Boolean = outerScopes.exists((outer) => Some(outer) == selectElement.parentQueryable)
 
   private def outerTarget: Option[SelectElement] = {
     val q =


### PR DESCRIPTION
parentQueryable returns an option so isDirectOuterReference will work if some scope is not a direct outer reference.

My real use-case was apparently more complex than the example test I had. I made the following change and it seemed to fix it for all of my cases. Do you see anything wrong with this change?

---

Minor Issue:

I also noticed a small issue with a subquery using the
     from(entities)(ent => select(&(ent.id)))

on postgres I got an error about: "ERROR: missing FROM-clause entry for table".

The query was: 

```
Select
  "OverrideConfig4"."pointId" as "OverrideConfig4_pointId",
  "OverrideConfig4"."id" as "OverrideConfig4_id",
  "OverrideConfig4"."protoData" as "OverrideConfig4_protoData"
From
  "OverrideConfig" "OverrideConfig4"
Where
  ("OverrideConfig4"."pointId" in ((Select
     "Point7"."id" as "Point7_id"
   From
     "Point" "Point7"
   Where
     ("Point7"."entityId" in ((Select
        "Entity13"."Entity13_id" as "v9"
      From
        (Select
           "Entity13"."name" as "Entity13_name",
           "Entity13"."id" as "Entity13_id"
         From
           "Entity" "Entity13"
         Where
           (("Entity13"."id" in ((Select
              "EntityEdge16"."childId" as "EntityEdge16_childId"
            From
              "EntityEdge" "EntityEdge16"
            Where
              (("EntityEdge16"."parentId" = ?) and ("EntityEdge16"."relationship" = ?))
           ) )) and ("Entity13"."id" in ((Select
              "EntityToTypeJoins19"."entityId" as "v18"
            From
              "EntityToTypeJoins" "EntityToTypeJoins19"
            Where
              ("EntityToTypeJoins19"."entType" in (?))
           ) )))
        )  "q10"
     ) ))
  ) ))
```

The issue is it uses:  "Entity13"."Entity13_id" instead of "q10"."Entity13_id". I was able to remove the &() for my case so I moved on but you might be able to figure out the cause of that bug as well.
