### PR TITLE
Fix for .leftOuter.inhibitWhen

### DIFF
--- a/src/main/scala/org/squeryl/dsl/AbstractQuery.scala
+++ b/src/main/scala/org/squeryl/dsl/AbstractQuery.scala
@@ -238,6 +238,7 @@ abstract class AbstractQuery[R](val isRoot:Boolean) extends Query[R] {
       val ojq = q.asInstanceOf[OuterJoinedQueryable[U]]
       val sq = createSubQueryable[U](ojq.queryable)
       sq.node.joinKind = Some((ojq.leftRightOrFull, "outer"))
+      sq.node.inhibited = ojq.inhibited
       new SubQueryable(sq.queryable, Some(sq.sample).asInstanceOf[U], sq.resultSetMapper, sq.isQuery, sq.node)
     }
     else if(q.isInstanceOf[InnerJoinedQueryable[U]]) {

--- a/src/main/scala/org/squeryl/dsl/internal/JoinedQueryable.scala
+++ b/src/main/scala/org/squeryl/dsl/internal/JoinedQueryable.scala
@@ -28,6 +28,18 @@ trait JoinedQueryable[A] extends Queryable[A] {
     org.squeryl.internals.Utils.throwError('OuterJoinedQueryable + " is a temporary class, not meant to become part of the ast")
 }
 
-class OuterJoinedQueryable[A](val queryable: Queryable[A], val leftRightOrFull: String) extends JoinedQueryable[Option[A]]
+class OuterJoinedQueryable[A](val queryable: Queryable[A], val leftRightOrFull: String) extends JoinedQueryable[Option[A]]{
+  
+  /**
+   * Allowing an implicit conversion from OuterJoinedQueryable to OptionalQueryable will trigger another conversion
+   * to InnerJoinedQueryable inside org.squeryl.dsl.boilerplate.JoinSignatures#join.  This also allows us to inhibit
+   * the table without using Option[Option[T]] in our results 
+   */
+  def inhibitWhen(inhibited: Boolean) = {
+    this.inhibited = inhibited
+    this
+  }
+  
+}
 
 class InnerJoinedQueryable[A](val queryable: Queryable[A], val leftRightOrFull: String) extends JoinedQueryable[A]


### PR DESCRIPTION
Fixed an issue where combining .leftOuter with .inhibitWhen led to an inner join being performed.  What would happen (I think) is that the .inhibitWhen would cause a conversion from OuterJoinedQueryable to OptionalQueryable which is not suitable for a join(...) so that would be converted via JoinSignatures.queryable2RightInnerJoinedQueryable into a InnerJoinedQueryable overriding the .leftOuter. 

Fixed by adding an inhibitWhen method on OuterJoinedQueryable and bypassing the conversion to OptionalQueryable altogether.  This also means that inhibiting a leftOuter will now result in an Option[T] rather than an Option[Option[T]] within the closure which is much easier to work with.
