### PR TITLE
Add implicit so that nvl on a Timestamp followed by >= compiles

### DIFF
--- a/src/main/scala/org/squeryl/dsl/TypeArithmetic.scala
+++ b/src/main/scala/org/squeryl/dsl/TypeArithmetic.scala
@@ -426,6 +426,7 @@ trait TypeArithmetic extends FieldTypes {
   implicit def unaryOpConv18(op: UnaryAgregateLengthNeutralOp[Option[TimestampType]]) = new DateTypeConversion[Option[TimestampType]](op)(createOutMapperTimestampTypeOption)
 
   implicit def nvl1(e: NvlFunctionNonNumerical[Option[DateType],DateType]) = new DateTypeConversion[DateType](e)
+  implicit def nvl4(e: NvlFunctionNonNumerical[Option[TimestampType], TimestampType]) = new DateTypeConversion[TimestampType](e)
   implicit def nvl2(e: NvlFunctionNonNumerical[Option[StringType],StringType]) = new StringTypeConversion[StringType](e)
   implicit def nvl3(e: NvlFunctionNonNumerical[Option[BooleanType],BooleanType]) = new BooleanTypeConversion[BooleanType](e)
 

--- a/src/test/scala/org/squeryl/test/musicdb/MusicDb.scala
+++ b/src/test/scala/org/squeryl/test/musicdb/MusicDb.scala
@@ -48,7 +48,7 @@ class MusicDbObject extends KeyedEntity[Int] {
   var timeOfLastUpdate = new Timestamp(System.currentTimeMillis)
 }
 
-class Person(var firstName:String, var lastName: String, val age: Option[Int]) extends MusicDbObject{
+class Person(var firstName:String, var lastName: String, val age: Option[Int], val created: Option[Timestamp] = None) extends MusicDbObject{
   def this() = this("", "", None)
 }
 
@@ -79,7 +79,7 @@ class MusicDb extends Schema {
 class TestData(schema : MusicDb){
   import schema._
   val herbyHancock = artists.insert(new Person("Herby", "Hancock", Some(68)))
-  val ponchoSanchez = artists.insert(new Person("Poncho", "Sanchez", None))
+  val ponchoSanchez = artists.insert(new Person("Poncho", "Sanchez", None, Some(new Timestamp(5))))
   val mongoSantaMaria = artists.insert(new Person("Mongo", "Santa Maria", None))
   val alainCaron = artists.insert(new Person("Alain", "Caron", None))
   val hossamRamzy = artists.insert(new Person("Hossam", "Ramzy", None))
@@ -639,6 +639,11 @@ abstract class MusicDbTestRun extends SchemaTester with QueryTester with RunTest
       
       passed('testTimestampDownToMillis)
     }
+  }
+
+  test("nvl followed by >= on Timestamp") {
+    val timestamp = new Timestamp(0L)
+    from(artists)(a => select(nvl(a.created, new Timestamp(10L)) >= timestamp)).size should be >= 0
   }
   
   test("validateScalarQuery1") {


### PR DESCRIPTION
Previously, the compiler would report the following error:

value >= is not a member of org.squeryl.dsl.NvlFunctionNonNumerical[Option[org.squeryl.PrimitiveTypeMode.TimestampType],org.squeryl.PrimitiveTypeMode.TimestampType]
