### PR TITLE
Added prototype prepared statement caching.

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="Encoding" useUTFGuessing="true" native2AsciiForPropertiesFiles="false" defaultCharsetForPropertiesFiles="UTF-8">
-    <file url="file://$PROJECT_DIR$/src/main/scala/org/squeryl/dsl/ManyToMany.scala" charset="UTF-8" />
-  </component>
+  <component name="Encoding" useUTFGuessing="true" native2AsciiForPropertiesFiles="false" />
 </project>
 

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,58 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="DependencyValidationManager">
-    <option name="SKIP_IMPORT_STATEMENTS" value="false" />
-  </component>
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
-  <component name="IdProvider" IDEtalkID="B1E3C31DCEBA989C6A50E84DC67DA930" />
-  <component name="JavadocGenerationManager">
-    <option name="OUTPUT_DIRECTORY" />
-    <option name="OPTION_SCOPE" value="protected" />
-    <option name="OPTION_HIERARCHY" value="true" />
-    <option name="OPTION_NAVIGATOR" value="true" />
-    <option name="OPTION_INDEX" value="true" />
-    <option name="OPTION_SEPARATE_INDEX" value="true" />
-    <option name="OPTION_DOCUMENT_TAG_USE" value="false" />
-    <option name="OPTION_DOCUMENT_TAG_AUTHOR" value="false" />
-    <option name="OPTION_DOCUMENT_TAG_VERSION" value="false" />
-    <option name="OPTION_DOCUMENT_TAG_DEPRECATED" value="true" />
-    <option name="OPTION_DEPRECATED_LIST" value="true" />
-    <option name="OTHER_OPTIONS" value="" />
-    <option name="HEAP_SIZE" />
-    <option name="LOCALE" />
-    <option name="OPEN_IN_BROWSER" value="true" />
-  </component>
-  <component name="NullableNotNullManager">
-    <option name="myDefaultNullable" value="org.jetbrains.annotations.Nullable" />
-    <option name="myDefaultNotNull" value="org.jetbrains.annotations.NotNull" />
-    <option name="myNullables">
-      <value>
-        <list size="0" />
-      </value>
-    </option>
-    <option name="myNotNulls">
-      <value>
-        <list size="3">
-          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
-          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
-          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
-        </list>
-      </value>
-    </option>
-  </component>
-  <component name="ProjectDetails">
-    <option name="projectName" value="Squeryl" />
-  </component>
+  <component name="IdProvider" IDEtalkID="1F576D751E4FF40626C3A7FBD9EB8E83" />
   <component name="ProjectResources">
     <default-html-doctype>http://www.w3.org/1999/xhtml</default-html-doctype>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_5" assert-keyword="true" jdk-15="true" project-jdk-name="1.6" project-jdk-type="JavaSDK">
-    <output url="file://$PROJECT_DIR$/../zaza123" />
-  </component>
-  <component name="SvnBranchConfigurationManager">
-    <option name="mySupportsUserInfoFilter" value="true" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="WebServicesPlugin" addRequiredLibraries="true" />
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,7 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/src/main/Main.iml" filepath="$PROJECT_DIR$/src/main/Main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/src/test/Tests.iml" filepath="$PROJECT_DIR$/src/test/Tests.iml" />
+      <module fileurl="file://$PROJECT_DIR$/src/test/Test.iml" filepath="$PROJECT_DIR$/src/test/Test.iml" />
     </modules>
   </component>
 </project>

--- a/project/plugins/project/build.properties
+++ b/project/plugins/project/build.properties
@@ -1,3 +1,3 @@
 #Project properties
-#Sat Sep 03 12:18:33 EEST 2011
+#Fri Oct 28 20:50:00 BST 2011
 plugin.uptodate=true

--- a/src/main/Main.iml
+++ b/src/main/Main.iml
@@ -3,8 +3,8 @@
   <component name="FacetManager">
     <facet type="scala" name="Scala">
       <configuration>
-        <option name="compilerLibraryLevel" value="Global" />
-        <option name="compilerLibraryName" value="Scala2.9.0-1" />
+        <option name="compilerLibraryLevel" value="Project" />
+        <option name="compilerLibraryName" value="compile" />
       </configuration>
     </facet>
   </component>
@@ -15,7 +15,7 @@
     </content>
     <orderEntry type="jdk" jdkName="1.6" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module-library" exported="">
+    <orderEntry type="module-library">
       <library>
         <CLASSES>
           <root url="jar://$MODULE_DIR$/../../lib_managed/scala_2.8.1/compile/cglib-nodep-2.2.jar!/" />
@@ -24,11 +24,20 @@
         <SOURCES />
       </library>
     </orderEntry>
-    <orderEntry type="library" exported="" name="Scala2.9.0-1" level="application" />
-    <orderEntry type="module-library" exported="">
+    <orderEntry type="library" name="Scala2.9.0-1" level="application" />
+    <orderEntry type="module-library">
       <library>
         <CLASSES>
           <root url="jar://$MODULE_DIR$/../../lib_managed/scala_2.9.0-1/compile/scalap-2.9.0-1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/scala-lang/scala-library/2.9.1/scala-library-2.9.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/src/main/scala/org/squeryl/internals/FieldReferenceLinker.scala
+++ b/src/main/scala/org/squeryl/internals/FieldReferenceLinker.scala
@@ -239,7 +239,7 @@ object FieldReferenceLinker {
     visited.add(idHashCode)
     
     _populateSelectCols(yi, q, o)
-    for(f <- clazz.getDeclaredFields) {
+    for(f <- clazz.getDeclaredFields) { // todo: cache getDeclaredFields
       f.setAccessible(true);
       val ob = f.get(o)
 


### PR DESCRIPTION
I could find prepared statements being used in `Table.insert` and `table._batchedUpdateOrInsert`. Instances
are cached under a string ID for now. As we only have inserts and updates on single tables, these are
currently `<table.name>.{insert,update}`.
