### PR TITLE
 composite primary key constraint in postgress now generate creation of ...

### DIFF
--- a/src/main/scala/org/squeryl/Schema.scala
+++ b/src/main/scala/org/squeryl/Schema.scala
@@ -141,7 +141,7 @@ trait Schema {
       statementHandler("-- composite key indexes :")
     
     for(cpk <- compositePKs) {
-      val createConstraintStmt = _dbAdapter.writeUniquenessConstraint(cpk._1, cpk._2)
+      val createConstraintStmt = _dbAdapter.writeCompositePrimaryKeyConstraint(cpk._1, cpk._2)
       statementHandler(createConstraintStmt + ";")
     }
 
@@ -179,7 +179,7 @@ trait Schema {
     if(_dbAdapter.supportsForeignKeyConstraints)
       _declareForeignKeyConstraints
 
-    _createUniqueConstraintsOfCompositePKs
+    _createConstraintsOfCompositePKs
 
     createColumnGroupConstraintsAndIndexes
   }
@@ -271,9 +271,9 @@ trait Schema {
     }
   }
 
-  private def _createUniqueConstraintsOfCompositePKs =
+  private def _createConstraintsOfCompositePKs =
     for(cpk <- _allCompositePrimaryKeys) {
-      val createConstraintStmt = _dbAdapter.writeUniquenessConstraint(cpk._1, cpk._2)
+      val createConstraintStmt = _dbAdapter.writeCompositePrimaryKeyConstraint(cpk._1, cpk._2)
       _executeDdl(createConstraintStmt)
     }  
 

--- a/src/main/scala/org/squeryl/adapters/PostgreSqlAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/PostgreSqlAdapter.scala
@@ -18,7 +18,7 @@ package org.squeryl.adapters
 import org.squeryl.dsl.ast.FunctionNode
 import java.sql.{ResultSet, SQLException}
 import java.util.UUID
-import org.squeryl.internals.{StatementWriter, DatabaseAdapter}
+import org.squeryl.internals.{StatementWriter, DatabaseAdapter, FieldMetaData}
 import org.squeryl.{Session, Table}
 
 class PostgreSqlAdapter extends DatabaseAdapter {
@@ -88,6 +88,19 @@ class PostgreSqlAdapter extends DatabaseAdapter {
 
   override def isTableDoesNotExistException(e: SQLException) =
    e.getSQLState.equals("42P01")
+
+  override def writeCompositePrimaryKeyConstraint(t: Table[_], cols: Iterable[FieldMetaData]) =
+  {
+    // alter table TableName add primary key (col1, col2) ;
+    val sb = new StringBuilder(256)
+    sb.append("alter table ")
+    sb.append(quoteName(t.prefixedName))
+    sb.append(" add primary key (")
+    sb.append(cols.map(_.columnName).map(quoteName(_)).mkString(","))
+    sb.append(")")
+    sb.toString
+  }
+
 
   override def writeDropForeignKeyStatement(foreignKeyTable: Table[_], fkName: String) =
     "alter table " + quoteName(foreignKeyTable.prefixedName) + " drop constraint " + quoteName(fkName)

--- a/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
+++ b/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
@@ -665,6 +665,9 @@ trait DatabaseAdapter {
   def dropTable(t: Table[_]) =
     execFailSafeExecute(writeDropTable(t.prefixedName), e=> isTableDoesNotExistException(e))
 
+  def writeCompositePrimaryKeyConstraint(t: Table[_], cols: Iterable[FieldMetaData]) = 
+      writeUniquenessConstraint(t, cols);
+
   def writeUniquenessConstraint(t: Table[_], cols: Iterable[FieldMetaData]) = {
     //ALTER TABLE TEST ADD CONSTRAINT NAME_UNIQUE UNIQUE(NAME)
     val sb = new StringBuilder(256)


### PR DESCRIPTION
...real primary key, not unique constraint as before

(in postgresql we need composite primary keys be created as primary keys, not unique indexes.  (i.e. by
alter table TableName add primary key(col1,col2)   )

So, this patch do this for postgres and slightly change database adapter trait to allow defining of composite-primary-key creation behaviour in concrete db adapter.

PS.  Note, that you also have paper letter  with my contribute agreement. I can resend one if needed. 

Best Regards !
