### PR TITLE
Fixes for batched updates and composite PKs

### DIFF
--- a/src/main/scala/org/squeryl/Table.scala
+++ b/src/main/scala/org/squeryl/Table.scala
@@ -219,7 +219,7 @@ class Table[T] private [squeryl] (n: String, c: Class[T], val schema: Schema, _p
 
             fields = Some(ck._fields.toList)
 
-            null
+            new EqualityExpression(new InputOnlyConstantExpressionNode(1), new InputOnlyConstantExpressionNode(1))
           })
 
           fields getOrElse (internals.Utils.throwError("No PK fields found"))

--- a/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
+++ b/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
@@ -499,7 +499,7 @@ trait DatabaseAdapter {
           val fieldWhere = ck._fields map (fmd => quoteName(fmd.columnName) + " = " + writeValue(o_, fmd, sw))
           sw.write(fieldWhere.mkString(" and "))
 
-          null
+          new EqualityExpression(new InputOnlyConstantExpressionNode(1), new InputOnlyConstantExpressionNode(1))
         })
       }
     )


### PR DESCRIPTION
Hi Max,

Here are a couple of fixes for batched updates and composite PKs.  21e8bc0d is a pretty trivial fix.   With 2ce2a40d, we need JDBC params for the PK.  The way I did this is not exactly pretty so please let me know if there is a better way of doing this.  

(either way, I'll mash the two commits together and commit as one to master once you're happy with the changes...)

Pete
