### PR TITLE
Probably the beforeUpdate lifecycle event should refer BeforeUpdate of PosoLifecycleEvent?

### DIFF
--- a/src/main/scala/org/squeryl/Schema.scala
+++ b/src/main/scala/org/squeryl/Schema.scala
@@ -558,7 +558,7 @@ trait Schema {
     new LifecycleEventPercursorClass[A](m.erasure, this, BeforeInsert)
 
   protected def beforeUpdate[A](t: Table[A]) =
-    new LifecycleEventPercursorTable[A](t, BeforeInsert)
+    new LifecycleEventPercursorTable[A](t, BeforeUpdate)
 
   protected def beforeUpdate[A]()(implicit m: Manifest[A]) =
     new LifecycleEventPercursorClass[A](m.erasure, this, BeforeUpdate)


### PR DESCRIPTION
I was reading through Squeryl's code while looking at the lifecycle implementation and came across the following code,  apologies if I misunderstood something or it is an non-issue.

I used the Github editing on-the-fly, so I have not tested the code in any way
