### PR TITLE
Postgres auto-increment sequence name referencing fixed.

### DIFF
--- a/src/main/scala/org/squeryl/adapters/PostgreSqlAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/PostgreSqlAdapter.scala
@@ -23,6 +23,13 @@ import org.squeryl.{Session, Table}
 
 class PostgreSqlAdapter extends DatabaseAdapter {
 
+  /**
+   * NB: You can override `usePostgresSequenceNamingScheme` to return true in a
+   * child class to change the sequence naming behavior to align with the
+   * default postgresql scheme.
+   */
+  def usePostgresSequenceNamingScheme: Boolean = false
+
   override def intTypeDeclaration = "integer"
   override def stringTypeDeclaration = "varchar"
   override def stringTypeDeclaration(length:Int) = "varchar("+length+")"
@@ -54,18 +61,29 @@ class PostgreSqlAdapter extends DatabaseAdapter {
     }
   }                                               
 
-  def sequenceName(t: Table[_]) = {
-    val autoIncPK = t.posoMetaData.fieldsMetaData.find(fmd => fmd.isAutoIncremented)
-    t.name + "_" + autoIncPK.get.nameOfProperty + "_seq"
-  }
+  def sequenceName(t: Table[_]) =
+    if (usePostgresSequenceNamingScheme) {
+      // This is compatible with the default postgresql sequence naming scheme.
+      val autoIncPK = t.posoMetaData.fieldsMetaData.find(fmd => fmd.isAutoIncremented)
+      t.name + "_" + autoIncPK.get.nameOfProperty + "_seq"
+    } else {
+      // Use the legacy Squeryl sequence naming scheme.
+      t.prefixedPrefixedName("seq_")
+    }
 
   override def createSequenceName(fmd: FieldMetaData) =
-    fmd.parentMetaData.viewOrTable.name + "_" + fmd.columnName + "_seq"
+    if (usePostgresSequenceNamingScheme) {
+      // This is compatible with the default postgresql sequence naming scheme.
+      fmd.parentMetaData.viewOrTable.name + "_" + fmd.columnName + "_seq"
+    } else {
+      // Use the legacy Squeryl sequence naming scheme.
+      super.createSequenceName(fmd)
+    }
 
   override def writeConcatFunctionCall(fn: FunctionNode, sw: StatementWriter) =
     sw.writeNodesWithSeparator(fn.args, " || ", false)
   
-  override def writeInsert[T](o: T, t: Table[T], sw: StatementWriter):Unit = {
+  override def writeInsert[T](o: T, t: Table[T], sw: StatementWriter): Unit = {
 
     val o_ = o.asInstanceOf[AnyRef]
 


### PR DESCRIPTION
Max and friends,

This is a fix for Squeryl's Postgres compatibility.  Squeryl was trying to reference the auto-increment sequences as "s_&lt;tableName&gt;_id", but Postgres automatically names sequences "&lt;tableName&gt;_id_seq".  This commit updates the PG adapter to behave in a compatible manner by default.

All tests seemed to pass in SBT.

[info] Passed: : Total 125, Failed 0, Errors 0, Passed 120, Skipped 5
[success] Total time: 13 s, completed Aug 5, 2012 4:08:18 PM

Best,
Jay
