### PR TITLE
Update src/main/scala/org/squeryl/internals/DatabaseAdapter.scala

### DIFF
--- a/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
+++ b/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
@@ -235,11 +235,11 @@ trait DatabaseAdapter {
         sb.append(v)
     }
 
-    if(isPrimaryKey)
-      sb.append(" primary key")
-
     if(!fmd.isOption)
       sb.append(" not null")
+
+    if(isPrimaryKey)
+      sb.append(" primary key")
     
     if(supportsAutoIncrementInColumnDeclaration && fmd.isAutoIncremented)
       sb.append(" auto_increment")


### PR DESCRIPTION
Bug when creating schemas on H2. In H2, the "primary key" and "auto_increment" need to be next to eachother. If they are not, the table will fail to be created with this kind of error:

org.h2.jdbc.JdbcSQLException: Syntax error in SQL statement "CREATE TABLE CATEGORY (
     NAME VARCHAR(128) NOT NULL,
     ID BIGINT PRIMARY KEY NOT NULL AUTO_INCREMENT[*]
  ) "; expected "CHECK, REFERENCES, ,, )"; SQL statement:
