### PR TITLE
Assign ids to child values in update statements

### DIFF
--- a/src/main/scala/org/squeryl/dsl/ast/UpdateStatement.scala
+++ b/src/main/scala/org/squeryl/dsl/ast/UpdateStatement.scala
@@ -23,7 +23,7 @@ class UpdateStatement(_whereClause: Option[()=>LogicalBoolean], uas: Seq[UpdateA
   val whereClause: Option[LogicalBoolean] =
     _whereClause.map(_.apply)
 
-  override def children = whereClause.toList
+  override def children = whereClause.toList ++ values
 
   def doWrite(sw: StatementWriter) = {}
 


### PR DESCRIPTION
The right hand sides of children in an update statement's set clause may need a uniqueId, so it should be listed as a child node of UpdateStatement.
