### PR TITLE
SquerylSQLException#getCause is covariant

### DIFF
--- a/src/main/scala/org/squeryl/KeyedEntity.scala
+++ b/src/main/scala/org/squeryl/KeyedEntity.scala
@@ -122,7 +122,7 @@ object SquerylSQLException {
 
 class SquerylSQLException(message: String, cause: Option[SQLException]) extends RuntimeException(message, cause.orNull) {
   // Overridden to provide covariant return type as a convenience
-  override def getCause = cause.orNull
+  override def getCause: SQLException = cause.orNull
 }
 
 class StaleUpdateException(message: String) extends RuntimeException(message)


### PR DESCRIPTION
At least in 2.9.1 (and probably others), without the annotation all you get
back is a Throwable.
