### PR TITLE
Fixing bug when nesting inTransaction(SessionFactory)

### DIFF
--- a/src/main/scala/org/squeryl/dsl/QueryDsl.scala
+++ b/src/main/scala/org/squeryl/dsl/QueryDsl.scala
@@ -108,7 +108,7 @@ trait QueryDsl
     if(! Session.hasCurrentSession)
       _executeTransactionWithin(sf.newSession, a _)
     else
-      _executeTransactionWithin(Session.currentSession, a _)
+      a
 
    def transaction[A](s: Session)(a: =>A) = 
      _executeTransactionWithin(s, a _)


### PR DESCRIPTION
When nesting inTransaction(SessionFactory) statements, I get a

```
MySQLNonTransientConnectionException: No operations allowed after connection closed
```

The following examples work

```
inTransaction { inTransaction { ... } }
inTransaction(SessionFactory) { inTransaction { ... } }
```

But the following doesn't

```
inTransaction(SessionFactory) { inTransaction(SessionFactory) { ... } }
```

I looked at QueryDSL.scala and recognized, that the inTransaction(SessionFactory) {...} tries to enter a new session, also if there is already one there. The inTransaction without a session factory doesn't have this behaviour and just does nothing.

I think this also is what inTransaction(SessionFactory) should do, so I sent this pull request.

However, I'm not very used to the squeryl internals. So if there is a reason why inTransaction(SessionFactory) is implemented this way, please discard this pull request.
