### PR TITLE
Removed duplicate logging in executeUpdateForInsert

### DIFF
--- a/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
+++ b/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
@@ -370,8 +370,6 @@ trait DatabaseAdapter {
   }
 
   def executeUpdateForInsert(s: Session, sw: StatementWriter, ps: PreparedStatement) = exec(s, sw) { params =>
-    if(s.isLoggingEnabled)
-      s.log(sw.toString)
     fillParamsInto(params, ps)
     ps.executeUpdate
   }


### PR DESCRIPTION
When logging is enabled executeUpdateForInsert logs the SQL to insert twice. Once in _exec and once in method body.

I modified it so only the logging in _exec is executed.

Martin
