### PR TITLE
StatisticsListener.resultSetIterationEnded: Take statEx instead of statEx.uuid

### DIFF
--- a/src/main/scala/org/squeryl/dsl/AbstractQuery.scala
+++ b/src/main/scala/org/squeryl/dsl/AbstractQuery.scala
@@ -186,7 +186,7 @@ abstract class AbstractQuery[R](val isRoot:Boolean) extends Query[R] {
         stmt.close
 
         if(s.statisticsListener != None) {
-          s.statisticsListener.get.resultSetIterationEnded(statEx.uuid, System.currentTimeMillis, rowCount, true)
+          s.statisticsListener.get.resultSetIterationEnded(statEx, System.currentTimeMillis, rowCount, true)
         }
       }
       

--- a/src/main/scala/org/squeryl/logging/LocalH2SinkStatisticsListener.scala
+++ b/src/main/scala/org/squeryl/logging/LocalH2SinkStatisticsListener.scala
@@ -72,8 +72,8 @@ class LocalH2SinkStatisticsListener(val h2Session: Session) extends StatisticsLi
     h2Session.connection.commit
   }
 
-  def resultSetIterationEnded(invocationId: String, iterationEndTime: Long, rowCount: Int, iterationCompleted: Boolean) = _pushOp {
-    StatsSchema.recordEndOfIteration(invocationId, iterationEndTime: Long, rowCount: Int, iterationCompleted: Boolean)
+  def resultSetIterationEnded(se: StatementInvocationEvent, iterationEndTime: Long, rowCount: Int, iterationCompleted: Boolean) = _pushOp {
+    StatsSchema.recordEndOfIteration(se: StatementInvocationEvent, iterationEndTime: Long, rowCount: Int, iterationCompleted: Boolean)
     h2Session.connection.commit
   }
 

--- a/src/main/scala/org/squeryl/logging/StatisticsListener.scala
+++ b/src/main/scala/org/squeryl/logging/StatisticsListener.scala
@@ -37,7 +37,7 @@ trait StatisticsListener {
 
   def queryExecuted(se: StatementInvocationEvent): Unit
 
-  def resultSetIterationEnded(statementInvocationId: String, iterationEndTime: Long, rowCount: Int, iterationCompleted: Boolean): Unit
+  def resultSetIterationEnded(se: StatementInvocationEvent, iterationEndTime: Long, rowCount: Int, iterationCompleted: Boolean): Unit
 
   def updateExecuted(se: StatementInvocationEvent): Unit
 

--- a/src/main/scala/org/squeryl/logging/StatsSchema.scala
+++ b/src/main/scala/org/squeryl/logging/StatsSchema.scala
@@ -122,10 +122,10 @@ object StatsSchema extends Schema {
     si.id
   }
 
-  def recordEndOfIteration(statementInvocationId: String, iterationEndTime: Long, rowCount: Int, iterationCompleted: Boolean) = {
+  def recordEndOfIteration(se: StatementInvocationEvent, iterationEndTime: Long, rowCount: Int, iterationCompleted: Boolean) = {
 
     update(statementInvocations)(si =>
-      where(si.id === statementInvocationId)
+      where(si.id === se.uuid)
       set(si.iterationEndTime := Some(iterationEndTime), si.rowCount := Some(rowCount))
     )
   }


### PR DESCRIPTION
A small change that prevents the client from having to cache previous `StatementInvocationEvent`s that it's seen in order to, e.g., calculate how long it took to exhaust a result set.

No more objects are retained than before, so the memory semantics don't change.
