### PR TITLE
s/NonLocalReturnControl/ControlThrowable

### DIFF
--- a/src/main/scala/org/squeryl/dsl/QueryDsl.scala
+++ b/src/main/scala/org/squeryl/dsl/QueryDsl.scala
@@ -22,7 +22,7 @@ import org.squeryl.internals._
 import org.squeryl._
 import java.sql.{SQLException, ResultSet}
 import collection.mutable.ArrayBuffer
-import scala.runtime.NonLocalReturnControl
+import scala.util.control.ControlThrowable
 
 
 trait BaseQueryDsl {
@@ -162,7 +162,7 @@ trait QueryDsl
       res
     }
     catch {
-      case e:NonLocalReturnControl[_] => 
+      case e: ControlThrowable =>
       {
         txOk = true
         throw e


### PR DESCRIPTION
I think should not use `NonLocalReturnControl` directly. because it is internal implementation, not public API.

and also throw `ControlThrowable` if use `break` https://github.com/scala/scala/blob/v2.10.0/src/library/scala/util/control/Breaks.scala#L93
