### PR TITLE
Add Session.logQueryResults (default: true)

### DIFF
--- a/src/main/scala/org/squeryl/Session.scala
+++ b/src/main/scala/org/squeryl/Session.scala
@@ -39,6 +39,8 @@ class Session(val connection: Connection, val databaseAdapter: DatabaseAdapter, 
 
   var logUnclosedStatements = false
 
+  var logQueryResults = true
+
   private val _statements = new ArrayBuffer[Statement]
 
   private val _resultSets = new ArrayBuffer[ResultSet]

--- a/src/main/scala/org/squeryl/dsl/AbstractQuery.scala
+++ b/src/main/scala/org/squeryl/dsl/AbstractQuery.scala
@@ -207,7 +207,7 @@ abstract class AbstractQuery[R](val isRoot:Boolean) extends Query[R] {
         throw new NoSuchElementException("next called with no rows available")
       _nextCalled = false
 
-      if(s.isLoggingEnabled)
+      if(s.isLoggingEnabled && s.logQueryResults)
         s.log(ResultSetUtils.dumpRow(rs))
 
       give(resultSetMapper, rs)


### PR DESCRIPTION
It's often useful to log all queries sent to the db without also having to sift through all results sent back.

(Even better would be to use something like slf4j so that logging could be controlled on a per-module basis.)
