### PR TITLE
Corrected a typo in the where clause of documentation

### DIFF
--- a/pagination.textile
+++ b/pagination.textile
@@ -12,7 +12,7 @@ Example :
 
     def searchForBooks(title : String, offset: Int, pageLength: Int) =
       from(books)(b =>
-	    where(b => b.title like title)
+	    where(b.title like title)
 		select(b)
 		orderBy(b.title asc)
 	  ).page(offset, pageLength)


### PR DESCRIPTION
The documentation for this example didn't compile, so I removed the `b =>` to make the where clause simply contain a `LogicalBoolean`.
