### PR TITLE
Better support for underscores and uppercase together in variable names.

### DIFF
--- a/src/main/scala/org/squeryl/Schema.scala
+++ b/src/main/scala/org/squeryl/Schema.scala
@@ -92,7 +92,7 @@ class Schema(implicit val fieldMapper: FieldMapper) {
       name.toList.map(c => if(c.isUpper) "_" + c else c).mkString
       
     def snakify(name: String) =
-      name.replaceAll("^([^A-Za-z_])", "_$1").replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2").replaceAll("([a-z0-9])([A-Z])", "$1_$2").toLowerCase
+      name.replaceAll("^([^A-Za-z_])", "_$1").replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2").replaceAll("([^A-Z])([A-Z])", "$1_$2").toLowerCase
   }
 
   def columnNameFromPropertyName(propertyName: String) = propertyName


### PR DESCRIPTION
Can we support this use case?
Currently: variable `UserId` is translated into `user_id`, and `User_Id` into the same `user_id`.
With this PR the second case would be translated into `user__id`, allowing better mixing underscores and upper cases in variable names.
