### PR TITLE
removing invalid mssql with syntax

### DIFF
--- a/src/main/scala/org/squeryl/adapters/MSSQLServer.scala
+++ b/src/main/scala/org/squeryl/adapters/MSSQLServer.scala
@@ -137,11 +137,9 @@ class MSSQLServer extends DatabaseAdapter {
       val beginOffset = page._1
       val pageSize = page._2
 
-      sw.write("With ___z____ as (")
       sw.writeIndented {
         super.writeQuery(qen, sw, false, Some(" TOP " + (beginOffset + pageSize) + " "))
       }
-      sw.write(")")
     }
   
   private def _stripPrefix(selectE: String):String = {


### PR DESCRIPTION
The opening With **_z_**_ as ( and close ) cause the sql that is generated when a page is generated to be invalid.

Tests all pass with this change in place
