### PR TITLE
Support for ilike operator

### DIFF
--- a/src/main/scala/org/squeryl/dsl/TypedExpression.scala
+++ b/src/main/scala/org/squeryl/dsl/TypedExpression.scala
@@ -162,6 +162,8 @@ trait TypedExpression[A1,T1] extends ExpressionNode {
   
   def like[A2,T2 <: TOptionString](s: TypedExpression[A2,T2])(implicit ev: CanCompare[T1,T2]) = new BinaryOperatorNodeLogicalBoolean(this, s, "like")
   
+  def ilike[A2,T2 <: TOptionString](s: TypedExpression[A2,T2])(implicit ev: CanCompare[T1,T2]) = new BinaryOperatorNodeLogicalBoolean(this, s, "ilike")
+
   def ||[A2,T2](e: TypedExpression[A2,T2]) = new ConcatOp[A1,A2,T1,T2](this, e)
     
   def regex(pattern: String) = new FunctionNode(pattern, Seq(this)) with LogicalBoolean {


### PR DESCRIPTION
I noticed that there is no support for ILIKE operator, which is trivial to add. Hence this one liner. It is not urgent for me, because I have an implicit class with that function in my project.
