### PR TITLE
Expands compute() to take up to 22 arguments

### DIFF
--- a/src/main/scala/org/squeryl/dsl/boilerplate/ComputeMeasuresSignaturesFromGroupByState.scala
+++ b/src/main/scala/org/squeryl/dsl/boilerplate/ComputeMeasuresSignaturesFromGroupByState.scala
@@ -82,4 +82,186 @@ trait ComputeMeasuresSignaturesFromGroupByState[G] {
       this.unevaluatedHavingClause,
       () =>List(e1, e2, e3, e4, e5, e6, e7)
     )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_]): ComputeStateFromGroupByState[G,Product8[T1,T2,T3,T4,T5,T6,T7,T8]] =
+    new GroupWithMeasuresQueryYield[G,Product8[T1,T2,T3,T4,T5,T6,T7,T8]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_]): ComputeStateFromGroupByState[G,Product9[T1,T2,T3,T4,T5,T6,T7,T8,T9]] =
+    new GroupWithMeasuresQueryYield[G,Product9[T1,T2,T3,T4,T5,T6,T7,T8,T9]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_]): ComputeStateFromGroupByState[G,Product10[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10]] =
+    new GroupWithMeasuresQueryYield[G,Product10[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_]): ComputeStateFromGroupByState[G,Product11[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11]] =
+    new GroupWithMeasuresQueryYield[G,Product11[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_]): ComputeStateFromGroupByState[G,Product12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12]] =
+    new GroupWithMeasuresQueryYield[G,Product12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_]): ComputeStateFromGroupByState[G,Product13[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13]] =
+    new GroupWithMeasuresQueryYield[G,Product13[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_]): ComputeStateFromGroupByState[G,Product14[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14]] =
+    new GroupWithMeasuresQueryYield[G,Product14[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_]): ComputeStateFromGroupByState[G,Product15[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15]] =
+    new GroupWithMeasuresQueryYield[G,Product15[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_]): ComputeStateFromGroupByState[G,Product16[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16]] =
+    new GroupWithMeasuresQueryYield[G,Product16[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_],
+     e17: =>TypedExpression[T17,_]): ComputeStateFromGroupByState[G,Product17[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17]] =
+    new GroupWithMeasuresQueryYield[G,Product17[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_],
+     e17: =>TypedExpression[T17,_], e18: =>TypedExpression[T18,_]): ComputeStateFromGroupByState[G,Product18[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18]] =
+    new GroupWithMeasuresQueryYield[G,Product18[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17, e18)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_],
+     e17: =>TypedExpression[T17,_], e18: =>TypedExpression[T18,_], e19: =>TypedExpression[T19,_]): ComputeStateFromGroupByState[G,Product19[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19]] =
+    new GroupWithMeasuresQueryYield[G,Product19[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17, e18, e19)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_],
+     e17: =>TypedExpression[T17,_], e18: =>TypedExpression[T18,_], e19: =>TypedExpression[T19,_], e20: =>TypedExpression[T20,_]): ComputeStateFromGroupByState[G,Product20[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20]] =
+    new GroupWithMeasuresQueryYield[G,Product20[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17, e18, e19, e20)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_],
+     e17: =>TypedExpression[T17,_], e18: =>TypedExpression[T18,_], e19: =>TypedExpression[T19,_], e20: =>TypedExpression[T20,_],
+     e21: =>TypedExpression[T21,_]): ComputeStateFromGroupByState[G,Product21[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21]] =
+    new GroupWithMeasuresQueryYield[G,Product21[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17, e18, e19, e20, e21)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_],
+     e17: =>TypedExpression[T17,_], e18: =>TypedExpression[T18,_], e19: =>TypedExpression[T19,_], e20: =>TypedExpression[T20,_],
+     e21: =>TypedExpression[T21,_], e22: =>TypedExpression[T22,_]): ComputeStateFromGroupByState[G,Product22[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22]] =
+    new GroupWithMeasuresQueryYield[G,Product22[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22]](
+      this.queryElementzz,
+      this.groupByClauseClosure,
+      this.unevaluatedHavingClause,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17, e18, e19, e20, e21, e22)
+    )
 }

--- a/src/main/scala/org/squeryl/dsl/boilerplate/ComputeMeasuresSignaturesFromStartOrWhereState.scala
+++ b/src/main/scala/org/squeryl/dsl/boilerplate/ComputeMeasuresSignaturesFromStartOrWhereState.scala
@@ -69,4 +69,157 @@ trait ComputeMeasuresSignaturesFromStartOrWhereState {
       this,
       () =>List(e1, e2, e3, e4, e5, e6, e7)
     )
+
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_]): ComputeStateStartOrWhereState[Product8[T1,T2,T3,T4,T5,T6,T7,T8]] =
+    new MeasuresQueryYield[Product8[T1,T2,T3,T4,T5,T6,T7,T8]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_]): ComputeStateStartOrWhereState[Product9[T1,T2,T3,T4,T5,T6,T7,T8,T9]] =
+    new MeasuresQueryYield[Product9[T1,T2,T3,T4,T5,T6,T7,T8,T9]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_]): ComputeStateStartOrWhereState[Product10[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10]] =
+    new MeasuresQueryYield[Product10[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_]): ComputeStateStartOrWhereState[Product11[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11]] =
+    new MeasuresQueryYield[Product11[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_]): ComputeStateStartOrWhereState[Product12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12]] =
+    new MeasuresQueryYield[Product12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_]): ComputeStateStartOrWhereState[Product13[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13]] =
+    new MeasuresQueryYield[Product13[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_]): ComputeStateStartOrWhereState[Product14[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14]] =
+    new MeasuresQueryYield[Product14[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_]): ComputeStateStartOrWhereState[Product15[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15]] =
+    new MeasuresQueryYield[Product15[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_]): ComputeStateStartOrWhereState[Product16[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16]] =
+    new MeasuresQueryYield[Product16[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_],
+     e17: =>TypedExpression[T17,_]): ComputeStateStartOrWhereState[Product17[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17]] =
+    new MeasuresQueryYield[Product17[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_],
+     e17: =>TypedExpression[T17,_], e18: =>TypedExpression[T18,_]): ComputeStateStartOrWhereState[Product18[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18]] =
+    new MeasuresQueryYield[Product18[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17, e18)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_],
+     e17: =>TypedExpression[T17,_], e18: =>TypedExpression[T18,_], e19: =>TypedExpression[T19,_]): ComputeStateStartOrWhereState[Product19[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19]] =
+    new MeasuresQueryYield[Product19[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17, e18, e19)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_],
+     e17: =>TypedExpression[T17,_], e18: =>TypedExpression[T18,_], e19: =>TypedExpression[T19,_], e20: =>TypedExpression[T20,_]): ComputeStateStartOrWhereState[Product20[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20]] =
+    new MeasuresQueryYield[Product20[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17, e18, e19, e20)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_],
+     e17: =>TypedExpression[T17,_], e18: =>TypedExpression[T18,_], e19: =>TypedExpression[T19,_], e20: =>TypedExpression[T20,_],
+     e21: =>TypedExpression[T21,_]): ComputeStateStartOrWhereState[Product21[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21]] =
+    new MeasuresQueryYield[Product21[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17, e18, e19, e20, e21)
+    )
+
+  def compute[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22]
+    (e1: =>TypedExpression[T1,_], e2: =>TypedExpression[T2,_], e3: =>TypedExpression[T3,_], e4: =>TypedExpression[T4,_],
+     e5: =>TypedExpression[T5,_], e6: =>TypedExpression[T6,_], e7: =>TypedExpression[T7,_], e8: =>TypedExpression[T8,_],
+     e9: =>TypedExpression[T9,_], e10: =>TypedExpression[T10,_], e11: =>TypedExpression[T11,_], e12: =>TypedExpression[T12,_],
+     e13: =>TypedExpression[T13,_], e14: =>TypedExpression[T14,_], e15: =>TypedExpression[T15,_], e16: =>TypedExpression[T16,_],
+     e17: =>TypedExpression[T17,_], e18: =>TypedExpression[T18,_], e19: =>TypedExpression[T19,_], e20: =>TypedExpression[T20,_],
+     e21: =>TypedExpression[T21,_], e22: =>TypedExpression[T22,_]): ComputeStateStartOrWhereState[Product22[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22]] =
+    new MeasuresQueryYield[Product22[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22]](
+      this,
+      () =>List(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17, e18, e19, e20, e21, e22)
+    )
 }

--- a/src/main/scala/org/squeryl/dsl/boilerplate/SampleTuple.scala
+++ b/src/main/scala/org/squeryl/dsl/boilerplate/SampleTuple.scala
@@ -44,7 +44,21 @@ object SampleTuple {
       case 6 => new STuple6[Any,Any,Any,Any,Any,Any](n,m)
       case 7 => new STuple7[Any,Any,Any,Any,Any,Any,Any](n,m)
       case 8 => new STuple8[Any,Any,Any,Any,Any,Any,Any,Any](n,m)
-      case _ => org.squeryl.internals.Utils.throwError("Tuple9 is not supported, please send a request for supporting up to Product22")
+      case 9 => new STuple9[Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 10 => new STuple10[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 11 => new STuple11[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 12 => new STuple12[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 13 => new STuple13[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 14 => new STuple14[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 15 => new STuple15[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 16 => new STuple16[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 17 => new STuple17[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 18 => new STuple18[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 19 => new STuple19[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 20 => new STuple20[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 21 => new STuple21[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case 22 => new STuple22[Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any](n,m)
+      case _ => org.squeryl.internals.Utils.throwError("Tuple23 is not supported")
     }
 }
 
@@ -94,4 +108,88 @@ class STuple8[T1,T2,T3,T4,T5,T6,T7,T8]
   (n: List[SelectElement], m: Array[OutMapper[_]])
     extends STuple7[T1,T2,T3,T4,T5,T6,T7](n,m) with Product8[T1,T2,T3,T4,T5,T6,T7,T8] {
   def _8 = _get[T8](8)
+}
+
+class STuple9[T1,T2,T3,T4,T5,T6,T7,T8,T9]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple8[T1,T2,T3,T4,T5,T6,T7,T8](n,m) with Product9[T1,T2,T3,T4,T5,T6,T7,T8,T9] {
+  def _9 = _get[T9](9)
+}
+
+class STuple10[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple9[T1,T2,T3,T4,T5,T6,T7,T8,T9](n,m) with Product10[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10] {
+  def _10 = _get[T10](10)
+}
+
+class STuple11[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple10[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10](n,m) with Product11[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11] {
+  def _11 = _get[T11](11)
+}
+
+class STuple12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple11[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11](n,m) with Product12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12] {
+  def _12 = _get[T12](12)
+}
+
+class STuple13[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12](n,m) with Product13[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13] {
+  def _13 = _get[T13](13)
+}
+
+class STuple14[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple13[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13](n,m) with Product14[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14] {
+  def _14 = _get[T14](14)
+}
+
+class STuple15[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple14[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14](n,m) with Product15[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15] {
+  def _15 = _get[T15](15)
+}
+
+class STuple16[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple15[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15](n,m) with Product16[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16] {
+  def _16 = _get[T16](16)
+}
+
+class STuple17[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple16[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16](n,m) with Product17[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17] {
+  def _17 = _get[T17](17)
+}
+
+class STuple18[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple17[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17](n,m) with Product18[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18] {
+  def _18 = _get[T18](18)
+}
+
+class STuple19[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple18[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18](n,m) with Product19[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19] {
+  def _19 = _get[T19](19)
+}
+
+class STuple20[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple19[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19](n,m) with Product20[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20] {
+  def _20 = _get[T20](20)
+}
+
+class STuple21[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple20[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20](n,m) with Product21[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21] {
+  def _21 = _get[T21](21)
+}
+
+class STuple22[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22]
+  (n: List[SelectElement], m: Array[OutMapper[_]])
+    extends STuple21[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21](n,m) with Product22[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22] {
+  def _22 = _get[T22](22)
 }

--- a/src/main/scala/org/squeryl/internals/ResultSetMapper.scala
+++ b/src/main/scala/org/squeryl/internals/ResultSetMapper.scala
@@ -144,7 +144,22 @@ class ColumnToTupleMapper(val outMappers: Array[OutMapper[_]]) {
       case 5 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs))
       case 6 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs))
       case 7 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs))
-      //TODO: implement tuples results of size up to 22
+      case 8 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs))
+      case 9 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs))
+      case 10 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs))
+      case 11 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs))
+      case 12 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs))
+      case 13 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs))
+      case 14 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs))
+      case 15 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs))
+      case 16 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs), m(15).map(rs))
+      case 17 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs), m(15).map(rs), m(16).map(rs))
+      case 18 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs), m(15).map(rs), m(16).map(rs), m(17).map(rs))
+      case 19 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs), m(15).map(rs), m(16).map(rs), m(17).map(rs), m(18).map(rs))
+      case 20 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs), m(15).map(rs), m(16).map(rs), m(17).map(rs), m(18).map(rs), m(19).map(rs))
+      case 21 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs), m(15).map(rs), m(16).map(rs), m(17).map(rs), m(18).map(rs), m(19).map(rs), m(20).map(rs))
+      case 22 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs), m(15).map(rs), m(16).map(rs), m(17).map(rs), m(18).map(rs), m(19).map(rs), m(20).map(rs), m(21).map(rs))
+
       case z:Any => org.squeryl.internals.Utils.throwError("tuples of size "+size+" and greater are not supported")
     }
     


### PR DESCRIPTION
I needed to select 11 different SUM() results from a table and was surprised to find that squeryl stopped at 7. This patch expands that to 22.
