### PR TITLE
Support for extended types in PostgreSQL database

### DIFF
--- a/src/main/scala/org/squeryl/adapters/PostgreSqlAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/PostgreSqlAdapter.scala
@@ -119,9 +119,9 @@ class PostgreSqlAdapter extends DatabaseAdapter {
    */
   override protected def writeValue(o: AnyRef, fmd: FieldMetaData, sw: StatementWriter): String =
     fmd.explicitDbTypeDeclaration match {
-      case Some(declaration) if !sw.isForDisplay => {
-        sw.addParam(FieldStatementParam(o, fmd))
-        f"?::$declaration"
+      case Some(declaration) if fmd.explicitDbTypeCast => {
+        val original = super.writeValue(o, fmd, sw)
+        s"$original::$declaration"
       }
       case _ => super.writeValue(o, fmd, sw)
     }

--- a/src/main/scala/org/squeryl/internals/ColumnAttribute.scala
+++ b/src/main/scala/org/squeryl/internals/ColumnAttribute.scala
@@ -47,9 +47,11 @@ case class PrimaryKey() extends ColumnAttribute
         with AttributeValidOnNumericalColumn
         with AttributeValidOnMultipleColumn
 
-case class DBType(val declaration: String) extends ColumnAttribute
+case class DBType(val declaration: String, val explicit: Boolean = false) extends ColumnAttribute
   with AttributeValidOnNonNumericalColumn
-  with AttributeValidOnNumericalColumn
+  with AttributeValidOnNumericalColumn {
+  def explicitCast = copy(explicit = true)
+}
 
 /**
  * Flag column as not accepting values on INSERT

--- a/src/main/scala/org/squeryl/internals/FieldMetaData.scala
+++ b/src/main/scala/org/squeryl/internals/FieldMetaData.scala
@@ -150,6 +150,11 @@ class FieldMetaData(
       Some(dbt.get.asInstanceOf[DBType].declaration)
   }
   
+  /**
+   * If explicit db type case has been requested
+   */
+  def explicitDbTypeCast: Boolean = _columnAttributes.find(_.isInstanceOf[DBType]).map(a => a.asInstanceOf[DBType].explicit).getOrElse(false)
+  
   def isTransient =
     _columnAttributes.exists(_.isInstanceOf[IsTransient])
 


### PR DESCRIPTION
It is a follow up on the question I sent on the mailing list to support enum types.

The code to use this feature would be:

```
on(samples)( s=> declare(
  s.status is(dbType("sample_status"), indexed)
))
```
