### PR TITLE
Improve error message if the Option type detection failed

### DIFF
--- a/src/main/scala/org/squeryl/internals/FieldMetaData.scala
+++ b/src/main/scala/org/squeryl/internals/FieldMetaData.scala
@@ -452,13 +452,18 @@ object FieldMetaData {
           createDefaultValue(fieldMapper, member, clsOfField, Some(typeOfField), colAnnotation)
         }
         catch {
-          case e:Exception => null
+          case e: Exception => {
+            var errorMessage = "Could not deduce Option[] type of field '" + name + "' of class " + parentMetaData.clasz.getName
+            if (!detectScalapOnClasspath()) errorMessage += "scalap option deduction not enabled. See: http://squeryl.org/scalap.html for more information."
+              throw new RuntimeException(errorMessage, e)
+          }
         }
 
       val deductionFailed =
         v match {
           case Some(None) => true
-          case a:Any  => (v == null)
+          case null => true
+          case a:Any  => false
         }
 
       if(deductionFailed) {


### PR DESCRIPTION
I have encountered this today. When running scala 2.10 and squeryl 0.9.6-RC3 without scalap in classpath the error was unrelated:

Caused by: scala.MatchError: null
    at org.squeryl.internals.FieldMetaData$$anon$1.build(FieldMetaData.scala:454) ~[FieldMetaData$$anon$1.class:0.9.6-RC3]

The reason is that match by null fails and no error about scalap is printed.

I have also changed the code to have the original exception as well. In includes valuable information. In my case it was

Caused by: scala.tools.scalap.scalax.rules.ScalaSigParserError: Unexpected failure
        at scala.tools.scalap.scalax.rules.Rules$$anonfun$expect$1.apply(Rules.scala:68) ~[Rules$$anonfun$expect$1.class:?]

Which I was not able to investigate without the stacktrace.
