### PR TITLE
Add support for CTEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ profileOfH2Tests.html
 *.h2.db
 *.trace.db
 .sbtconfig
+tags

--- a/src/main/scala/org/squeryl/Query.scala
+++ b/src/main/scala/org/squeryl/Query.scala
@@ -90,4 +90,6 @@ trait Query[R] extends Queryable[R] {
   def forUpdate: Query[R]
 
   def page(offset: Int, pageLength: Int): Query[R]
+
+  private [squeryl] def root: Option[Query[R]] = None
 }

--- a/src/main/scala/org/squeryl/adapters/H2Adapter.scala
+++ b/src/main/scala/org/squeryl/adapters/H2Adapter.scala
@@ -50,4 +50,6 @@ class H2Adapter extends DatabaseAdapter {
 
   override def isTableDoesNotExistException(e: SQLException): Boolean =
     e.getErrorCode == 42102
+
+  override def supportsCommonTableExpressions = false
 }

--- a/src/main/scala/org/squeryl/dsl/QueryDsl.scala
+++ b/src/main/scala/org/squeryl/dsl/QueryDsl.scala
@@ -130,16 +130,15 @@ trait QueryDsl
   
   implicit def __thisDsl:QueryDsl = this  
 
-  private class QueryElementsImpl[Cond](override val whereClause: Option[()=>LogicalBoolean])
-    extends QueryElements[Cond]
-
   def where(b: =>LogicalBoolean): WhereState[Conditioned] =
-    new QueryElementsImpl[Conditioned](Some(b _))
+    new fsm.QueryElementsImpl[Conditioned](Some(b _), Nil)
+
+  def withWith(queries: Query[_]*): WithState =
+    new fsm.WithState(queries.toList.map(_.copy(false, Nil)))
 
   def &[A,T](i: =>TypedExpression[A,T]): A =
     FieldReferenceLinker.pushExpressionOrCollectValue[A](i _)
     
-  
   implicit def typedExpression2OrderByArg[E <% TypedExpression[_,_]](e: E) = new OrderByArg(e)
 
   implicit def orderByArg2OrderByExpression(a: OrderByArg) = new OrderByExpression(a)

--- a/src/main/scala/org/squeryl/dsl/QueryDsl.scala
+++ b/src/main/scala/org/squeryl/dsl/QueryDsl.scala
@@ -133,7 +133,7 @@ trait QueryDsl
   def where(b: =>LogicalBoolean): WhereState[Conditioned] =
     new fsm.QueryElementsImpl[Conditioned](Some(b _), Nil)
 
-  def withWith(queries: Query[_]*): WithState =
+  def withCte(queries: Query[_]*): WithState =
     new fsm.WithState(queries.toList.map(_.copy(false, Nil)))
 
   def &[A,T](i: =>TypedExpression[A,T]): A =

--- a/src/main/scala/org/squeryl/dsl/QueryYield.scala
+++ b/src/main/scala/org/squeryl/dsl/QueryYield.scala
@@ -20,6 +20,8 @@ import boilerplate._
 import org.squeryl.internals.{ResultSetMapper}
 import java.sql.ResultSet
 
+import org.squeryl.Query
+
 trait QueryYield[R] {
 
   def invokeYield(resultSetMapper: ResultSetMapper, rs: ResultSet): R
@@ -31,7 +33,8 @@ trait QueryYield[R] {
     (Option[ExpressionNode],
      Option[ExpressionNode],
      Iterable[ExpressionNode],
-     Iterable[ExpressionNode])
+     Iterable[ExpressionNode],
+     Iterable[Query[_]])
 
   private [squeryl] var joinExpressions: Seq[()=>LogicalBoolean] = Nil
 

--- a/src/main/scala/org/squeryl/dsl/ast/QueryExpressionElements.scala
+++ b/src/main/scala/org/squeryl/dsl/ast/QueryExpressionElements.scala
@@ -59,4 +59,6 @@ trait QueryExpressionElements extends ExpressionNode {
   def groupByClause: Iterable[ExpressionNode]
 
   def orderByClause: Iterable[ExpressionNode]
+
+  def commonTableExpressions: Iterable[QueryExpressionElements]
 }

--- a/src/main/scala/org/squeryl/dsl/ast/QueryExpressionNode.scala
+++ b/src/main/scala/org/squeryl/dsl/ast/QueryExpressionNode.scala
@@ -19,12 +19,30 @@ import org.squeryl.internals._
 import org.squeryl.dsl.{QueryYield, AbstractQuery}
 import scala.collection.mutable.ListBuffer
 
-class QueryExpressionNode[R](_query: AbstractQuery[R],
+class QueryExpressionNode[R](val _query: AbstractQuery[R],
                              _queryYield:QueryYield[R],
                              val subQueries: Iterable[QueryableExpressionNode],
                              val views: Iterable[ViewExpressionNode[_]])
   extends QueryExpressionElements
     with QueryableExpressionNode {
+
+  private [squeryl] def cteRoot: Option[QueryExpressionElements] = {
+    def loop(current: Option[ExpressionNode]): Option[QueryExpressionElements] = {
+      current.flatMap { c =>
+        c.isInstanceOf[QueryExpressionNode[_]] match {
+          case true => c.asInstanceOf[QueryExpressionNode[_]]
+            .commonTableExpressions
+            .find(sameRoot_?)
+            .orElse(loop(c.parent))
+          case false => loop(c.parent)
+        }
+      }
+    }
+    loop(parent)
+  }
+
+  private [squeryl] def sameRoot_?(e: QueryExpressionNode[_]) =
+    _query.root.isDefined && _query.root == e._query.root
 
   def tableExpressions: Iterable[QueryableExpressionNode] = 
     List(views.filter(v => ! v.inhibited),
@@ -32,8 +50,16 @@ class QueryExpressionNode[R](_query: AbstractQuery[R],
 
   def isJoinForm = _queryYield.joinExpressions != Nil
 
-  val (whereClause, havingClause, groupByClause, orderByClause) =
+  val (whereClause, havingClause, groupByClause, orderByClause, ctes) =
      _queryYield.queryElements
+
+  val commonTableExpressions = ctes.map { q =>
+    if (! q.ast.isInstanceOf[QueryExpressionNode[_]]) {
+      Utils.throwError("A common table expression AST must be a QueryExpressionNode, not a " +
+        q.getClass.getSimpleName)
+    }
+    q.ast.asInstanceOf[QueryExpressionNode[_]]
+  }.toList
 
   private val unionClauses =
       _query.unions map (kindAndQ => new UnionExpressionNode(kindAndQ._1, kindAndQ._2.ast))
@@ -80,6 +106,7 @@ class QueryExpressionNode[R](_query: AbstractQuery[R],
   override def children =
     List(
       selectList.toList,
+      commonTableExpressions.toList,
       views.toList,
       subQueries.toList,
       tableExpressions.filter(e=> e.joinExpression != None).map(_.joinExpression.get).toList,  
@@ -133,45 +160,101 @@ class QueryExpressionNode[R](_query: AbstractQuery[R],
           idGen += 1
         }
       })
+
+      if (commonTableExpressions.nonEmpty) {
+        relabelCtes()
+      }
     }
+  }
+
+  private def relabelCtes(): Unit = {
+    val cteNodes = commonTableExpressions.map { cte =>
+      (cte, collectAliasedNodes(cte))
+    }
+
+    for {
+      ref <- collectCteRefs()
+      (cte, src) <- cteNodes.find(_._1.sameRoot_?(ref))
+    } {
+      copyUniqueIds(src, collectAliasedNodes(ref))
+    }
+  }
+
+  private def collectCteRefs(): List[QueryExpressionNode[_]] = {
+    val buf = new collection.mutable.ArrayBuffer[QueryExpressionNode[_]]()
+    visitDescendants((node, parent, i) => {
+      if (! commonTableExpressions.contains(node) &&
+        node.isInstanceOf[QueryExpressionNode[_]] &&
+        commonTableExpressions.exists(
+          e => e.sameRoot_?(node.asInstanceOf[QueryExpressionNode[_]]))) {
+
+        buf += node.asInstanceOf[QueryExpressionNode[_]]
+      }
+    })
+
+    buf.toList
+  }
+
+  private def collectAliasedNodes(e: ExpressionNode): List[UniqueIdInAliaseRequired] = {
+    val buf = new collection.mutable.ArrayBuffer[UniqueIdInAliaseRequired]()
+    e.visitDescendants((node, parent, i) => {
+      if ((node ne e) && node.isInstanceOf[UniqueIdInAliaseRequired]) {
+        buf += node.asInstanceOf[UniqueIdInAliaseRequired]
+      }
+    })
+    buf.toList
+  }
+
+  private def copyUniqueIds(src: List[UniqueIdInAliaseRequired], dest: List[UniqueIdInAliaseRequired]): Unit = {
+    src.zip(dest).collect { case (e1, e2) => e2.uniqueId = e1.uniqueId }
   }
 
   def selectList: Iterable[SelectElement] = _selectList
 
   def doWrite(sw: StatementWriter) = {
-    val isNotRoot = parent != None
-    val isContainedInUnion = parent map (_.isInstanceOf[UnionExpressionNode]) getOrElse (false)
+    def writeCompleteQuery = {
+      val isNotRoot = parent != None
+      val isContainedInUnion = parent map (_.isInstanceOf[UnionExpressionNode]) getOrElse (false)
 
-    if((isNotRoot && ! isContainedInUnion) || hasUnionQueryOptions) {
-      sw.write("(")
-      sw.indent(1)
+      if((isNotRoot && ! isContainedInUnion) || hasUnionQueryOptions) {
+        sw.write("(")
+        sw.indent(1)
+      }
+
+      if (! unionClauses.isEmpty) {
+        sw.write("(")
+        sw.nextLine
+        sw.indent(1)
+      }
+
+      sw.databaseAdapter.writeQuery(this, sw)
+
+      if (! unionClauses.isEmpty) {
+        sw.unindent(1)
+        sw.write(")")
+        sw.nextLine
+      }
+
+      unionClauses.foreach { u =>
+        u.write(sw)
+      }
+
+      if((isNotRoot && ! isContainedInUnion) || hasUnionQueryOptions) {
+        sw.unindent(1)
+        sw.write(") ")
+      }
+
+      if (hasUnionQueryOptions) {
+        sw.databaseAdapter.writeUnionQueryOptions(this, sw)
+      }
     }
 
-    if (! unionClauses.isEmpty) {
-      sw.write("(")
-      sw.nextLine
-      sw.indent(1)
-    }
-
-    sw.databaseAdapter.writeQuery(this, sw)
-
-    if (! unionClauses.isEmpty) {
-      sw.unindent(1)
-      sw.write(")")
-      sw.nextLine
-    }
-
-    unionClauses.foreach { u =>
-      u.write(sw)
-    }
-
-    if((isNotRoot && ! isContainedInUnion) || hasUnionQueryOptions) {
-      sw.unindent(1)
-      sw.write(") ")
-    }
-
-    if (hasUnionQueryOptions) {
-      sw.databaseAdapter.writeUnionQueryOptions(this, sw)
+    if (sw.databaseAdapter.supportsCommonTableExpressions) {
+      cteRoot.map { r =>
+        sw.databaseAdapter.writeCteReference(sw, r)
+      }.getOrElse(writeCompleteQuery)
+    } else {
+      writeCompleteQuery
     }
   }
 }

--- a/src/main/scala/org/squeryl/dsl/fsm/BaseQueryYield.scala
+++ b/src/main/scala/org/squeryl/dsl/fsm/BaseQueryYield.scala
@@ -21,6 +21,7 @@ import org.squeryl.dsl.boilerplate._
 import org.squeryl.internals.{FieldReferenceLinker, ResultSetMapper, ColumnToTupleMapper, OutMapper}
 import java.sql.ResultSet
 
+import org.squeryl.Query
 
 class BaseQueryYield[G]
   (val queryElementzz: QueryElements[_], val selectClosure: ()=>G)
@@ -67,8 +68,10 @@ class BaseQueryYield[G]
 
   def groupByClause: Iterable[ExpressionNode] = Iterable.empty
 
+  def commonTableExpressions: Iterable[Query[_]] = queryElementzz.commonTableExpressions
+
   def queryElements =
-    (whereClause, havingClause, groupByClause, orderByClause)
+    (whereClause, havingClause, groupByClause, orderByClause, commonTableExpressions)
 
   def computeClause:List[ExpressionNode] = List.empty
 
@@ -114,7 +117,7 @@ class GroupQueryYield[K] (
     new Group(rsm.groupKeysMapper.get.mapToTuple(rs))
 
   override def queryElements =
-    (whereClause, havingClause, groupByClause, orderByClause)
+    (whereClause, havingClause, groupByClause, orderByClause, commonTableExpressions)
 
   class SampleGroup[K](k:K)
     extends Group(k) {
@@ -144,7 +147,7 @@ class MeasuresQueryYield[M](
     new Measures(rsm.groupMeasuresMapper.get.mapToTuple(rs))
 
   override def queryElements =
-    (whereClause, havingClause, groupByClause, orderByClause)
+    (whereClause, havingClause, groupByClause, orderByClause, commonTableExpressions)
 
 
   class SampleMeasures[M](m:M)
@@ -189,7 +192,7 @@ extends BaseQueryYield[GroupWithMeasures[K,M]](_qe, null)
       super.havingClause
 
    override def queryElements =
-    (whereClause, havingClause, _groupByClauseClosure().map(e => e), orderByClause)
+    (whereClause, havingClause, _groupByClauseClosure().map(e => e), orderByClause, commonTableExpressions)
 
   override def invokeYield(rsm: ResultSetMapper, rs: ResultSet) =
     new GroupWithMeasures(rsm.groupKeysMapper.get.mapToTuple(rs), rsm.groupMeasuresMapper.get.mapToTuple(rs))

--- a/src/main/scala/org/squeryl/internals/FieldReferenceLinker.scala
+++ b/src/main/scala/org/squeryl/internals/FieldReferenceLinker.scala
@@ -329,7 +329,7 @@ object FieldReferenceLinker {
         if(isComposite)
           _compositeKeyMembers.set(Some(new ArrayBuffer[SelectElement]))
 
-        var res =
+        val res =
           if(m.getName.equals("toString") && m.getParameterTypes.length == 0)
             "sample:"+viewExpressionNode.view.name+"["+Integer.toHexString(System.identityHashCode(o)) + "]"
           else

--- a/src/test/scala/org/squeryl/h2/H2Tests.scala
+++ b/src/test/scala/org/squeryl/h2/H2Tests.scala
@@ -63,7 +63,7 @@ class H2_ConnectionClosing extends ConnectionClosingTest with H2_Connection {
 }
 class H2_LogicalBooleanObjTests extends LogicalBooleanObjTests with H2_Connection
 
-
+class H2_CommonTableExpressions extends schooldb.CommonTableExpressions with H2_Connection
 
 /*
  * Lazy

--- a/src/test/scala/org/squeryl/postgres/FooTest.scalax
+++ b/src/test/scala/org/squeryl/postgres/FooTest.scalax
@@ -1,0 +1,131 @@
+package org.squeryl.postgres
+
+import org.squeryl._
+import org.squeryl.dsl._
+import org.joda.time._
+import java.sql.Timestamp
+import java.sql.ResultSet
+import org.squeryl.adapters.H2Adapter
+
+/**
+ * PrimitiveTypeMode being a trait, can be extended to
+ * support additionnal field types than what the native JDBC.
+ *
+ *  To support a non JDBC native type, one extends PrimitiveTypeMode
+ *  and adds 4 new implicits in it's scope.   Then all aspects
+ *  of the Query DSL that are available for the native type
+ *  becomes available for the new type
+ *
+ *
+ */
+object MyCustomTypes extends PrimitiveTypeMode {
+
+  /**
+   * The 3 type arguments are :
+   * 1) Timestamp : the native JDBC type that will back our custom type (in this case JodaTime's DateTime)
+   * 2) The new type we want to support
+   * 3) One of the sealed traits defined here :
+   *   https://github.com/max-l/Squeryl/blob/AST-lifting-overhaul/src/main/scala/org/squeryl/dsl/TypedExpression.scala#L28
+   * This will define the behavior of the new type, we want that in the DSL it behaves like
+   * a timestamp, this will for example enable comparison operators (<, >, between, etc...)
+   * as well as min, max functions, if we chose TBoolean, then min max is not available,
+   * if we chose TBigDecimal (of TFloat), then avg, sum, etc become available.
+   *
+   */
+
+  implicit val jodaTimeTEF = new NonPrimitiveJdbcMapper[Timestamp, DateTime, TTimestamp](timestampTEF, this) {
+
+    /**
+     * Here we implement functions fo convert to and from the native JDBC type
+     */
+
+    def convertFromJdbc(t: Timestamp) = new DateTime(t)
+    def convertToJdbc(t: DateTime) = new Timestamp(t.getMillis())
+  }
+
+  /**
+   * We define this one here to allow working with Option of our new type, this allso
+   * allows the 'nvl' function to work
+   */
+  implicit val optionJodaTimeTEF = new TypedExpressionFactory[Option[DateTime], TOptionTimestamp]
+      with DeOptionizer[Timestamp, DateTime, TTimestamp, Option[DateTime], TOptionTimestamp] {
+
+    val deOptionizer = jodaTimeTEF
+  }
+
+  /**
+   * the following are necessary for the AST lifting
+   */
+  implicit def jodaTimeToTE(s: DateTime): TypedExpression[DateTime, TTimestamp] = jodaTimeTEF.create(s)
+
+  implicit def optionJodaTimeToTE(s: Option[DateTime]): TypedExpression[Option[DateTime], TOptionTimestamp] = optionJodaTimeTEF.create(s)
+
+}
+
+import MyCustomTypes._
+
+case class TimestampTester(val id: DateTime, val optionalTime: Option[DateTime]) extends KeyedEntity[DateTime] {
+}
+
+object TimestampTesterSchema extends Schema {
+
+  val timestampTester = table[TimestampTester]
+}
+
+object JodaTimeTests {
+
+  import TimestampTesterSchema._
+
+  def main(args: Array[String]): Unit = {
+
+    Class.forName("org.h2.Driver")
+    SessionFactory.concreteFactory = Some({
+      () =>
+        val s = Session.create(
+          java.sql.DriverManager.getConnection("jdbc:h2:~/test", "sa", ""),
+          new H2Adapter)
+        s.setLogger(println _)
+        s
+    })
+    transaction {
+      try { drop } catch { case e: Exception => {} }
+      create
+    }
+
+    test1
+  }
+
+  def test1 = transaction {
+
+    val d = (new DateTime)
+
+    val b10 = d.minusDays(10)
+    val b5 = d.minusDays(5)
+    val a5 = d.plusDays(5)
+
+    timestampTester.insert(new TimestampTester(b10, Some(b10)))
+    timestampTester.insert(new TimestampTester(b5, Some(new DateTime)))
+    timestampTester.insert(new TimestampTester(a5, Some(new DateTime)))
+
+    /*
+    val x1 =
+      from(timestampTester)(tt =>
+        where(tt.time < b5)
+        select (&(tt.time)))
+
+    assert(x1.size == 1)
+
+    println(x1.mkString("\n"))
+    */
+
+    val q =
+      from(timestampTester)(tt => select(tt))
+
+    val h = q.toList.head
+
+    println(timestampTester.refresh(h))
+  }
+}
+
+
+

--- a/src/test/scala/org/squeryl/postgres/FooTest3.scalax
+++ b/src/test/scala/org/squeryl/postgres/FooTest3.scalax
@@ -1,0 +1,51 @@
+package org.squeryl.postgres
+
+import org.squeryl._
+import org.squeryl.dsl._
+import java.sql.Timestamp
+import java.sql.ResultSet
+import adapters.{PostgreSqlAdapter, H2Adapter}
+
+import java.util.{Map => JMap, Collections}
+
+object MyTypes extends PrimitiveTypeMode
+
+import MyTypes._
+
+case class HstoreTest(id: Int, foo: JMap[AnyRef, AnyRef]) extends KeyedEntity[Int] {
+}
+
+object HstoreTester extends Schema {
+
+  val hstoretest = table[HstoreTest]("hstoretest")
+}
+
+object FooTest3 {
+
+  import HstoreTester._
+
+  def main(args: Array[String]): Unit = {
+
+    Class.forName("org.postgresql.Driver")
+
+    SessionFactory.concreteFactory = Some({
+      () =>
+        val s = Session.create(
+          java.sql.DriverManager.getConnection("jdbc:postgresql:squeryl", "squeryl", "squeryl"),
+          new PostgreSqlAdapter)
+        s.setLogger(println _)
+        s
+    })
+
+    test1
+  }
+
+  def test1 = transaction {
+    val x = from(hstoretest)(h => select(h)).toList
+
+    println(x)
+  }
+}
+
+
+

--- a/src/test/scala/org/squeryl/postgres/FooTestX.scalax
+++ b/src/test/scala/org/squeryl/postgres/FooTestX.scalax
@@ -1,0 +1,56 @@
+package org.squeryl.postgres
+
+import org.squeryl._
+import adapters._
+import dsl._
+
+import PrimitiveTypeMode._
+
+case class Foo(
+    val id: Int
+  ) extends KeyedEntity[Int] {
+}
+
+object FooSchema extends Schema {
+  val foos = table[Foo]
+}
+
+object FooTestX extends App {
+  Class.forName("org.postgresql.Driver")
+
+  SessionFactory.concreteFactory =
+    Some(() => {
+      val c = java.sql.DriverManager.getConnection(
+        "jdbc:postgresql://localhost:5432/squeryl",
+        "squeryl",
+        "squeryl"
+      )
+      c.setAutoCommit(false)
+      val s = Session.create(c, new PostgreSqlAdapter)
+
+      s.setLogger(println)
+
+      s
+    })
+
+
+  import FooSchema._
+
+  transaction {
+    val qFoos = from(foos) ((f) => select(f))
+    val q =
+      from(qFoos)(s =>
+        where(exists(from(foos)((a) =>
+          where(exists
+            (from(foos) ( (a2) =>
+              where(s.id === 1)
+                select(&(3)))))
+            select(&(2)))))
+          select(&(1))
+      )
+
+    println(q.toString)
+
+    println(q.toList)
+  }
+}

--- a/src/test/scala/org/squeryl/postgres/PostgresTests.scala
+++ b/src/test/scala/org/squeryl/postgres/PostgresTests.scala
@@ -45,6 +45,8 @@ class Postgresql_ConnectionClosing extends ConnectionClosingTest with Postgresql
   def dbSpecificSelectNow: String = "select now()"
 }
 
+class Postgresql_CommonTableExpressions extends schooldb.CommonTableExpressions with Postgresql_Connection
+
 
 class Postgresql_LogicalBooleanObjTests extends LogicalBooleanObjTests with Postgresql_Connection
 

--- a/src/test/scala/org/squeryl/test/schooldb/SchoolDb.scala
+++ b/src/test/scala/org/squeryl/test/schooldb/SchoolDb.scala
@@ -424,7 +424,7 @@ abstract class CommonTableExpressions extends SchoolDbTestBase {
 
     val q =
       from(qStudents)(s =>
-        withWith(qStudents, qAddresses)
+        withCte(qStudents, qAddresses)
         where(exists(
           join(qStudents, qStudents)((s2, s3) =>
             where(s2.name === "Xiao" and exists(
@@ -438,7 +438,7 @@ abstract class CommonTableExpressions extends SchoolDbTestBase {
     /*
     val q =
       from(qStudents)(s =>
-        withWith(qStudents)
+        withCte(qStudents)
         select(s))
     */
 
@@ -1885,7 +1885,7 @@ abstract class SchoolDbTestRun extends SchoolDbTestBase {
 
     val q =
       from(qStudents)(s =>
-        withWith(qStudents, qAddresses)
+        withCte(qStudents, qAddresses)
         where(exists(
           join(qStudents, qStudents)((s2, s3) =>
             where(s2.name === "Xiao" and exists(


### PR DESCRIPTION
Adds support for non-recursive Common Table Expressions (CTEs). http://www.postgresql.org/docs/9.3/static/queries-with.html

For database that don't support them, the query is rendered as usual.