### PR TITLE
SQLite support

### DIFF
--- a/org.squeryl.tests.cfg
+++ b/org.squeryl.tests.cfg
@@ -3,6 +3,8 @@ h2.connectionString=jdbc:h2:~/test
 h2.user=sa
 h2.password=
 
+sqlite.connectionString=jdbc:sqlite:test
+
 #postgresql.connectionString=jdbc:postgresql://localhost:5432/test
 #postgresql.user=test
 #postgresql.password=test

--- a/org.squeryl.tests.cfg
+++ b/org.squeryl.tests.cfg
@@ -3,7 +3,7 @@ h2.connectionString=jdbc:h2:~/test
 h2.user=sa
 h2.password=
 
-sqlite.connectionString=jdbc:sqlite:test
+#sqlite.connectionString=jdbc:sqlite:test
 
 #postgresql.connectionString=jdbc:postgresql://localhost:5432/test
 #postgresql.user=test

--- a/project/SquerylBuild.scala
+++ b/project/SquerylBuild.scala
@@ -82,6 +82,7 @@ object SquerylBuild extends Build {
         "postgresql" % "postgresql" % "8.4-701.jdbc4" % "provided",
         "net.sourceforge.jtds" % "jtds" % "1.2.4" % "provided",
         "org.apache.derby" % "derby" % "10.7.1.1" % "provided",
+        "org.xerial" % "sqlite-jdbc" % "3.8.7" % "test",
         "junit" % "junit" % "4.8.2" % "provided"
       ),
       libraryDependencies <++= scalaVersion { sv =>

--- a/src/main/scala/org/squeryl/adapters/SQLiteAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/SQLiteAdapter.scala
@@ -22,8 +22,6 @@ import org.squeryl.dsl.ast.{ExpressionNode, QueryExpressionElements}
 import org.squeryl._
 import org.squeryl.internals._
 
-import scala.collection.mutable.ArrayBuffer
-
 class SQLiteAdapter extends DatabaseAdapter {
 
   override def uuidTypeDeclaration = "uuid"

--- a/src/main/scala/org/squeryl/adapters/SQLiteAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/SQLiteAdapter.scala
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright 2010 Maxime Lévesque
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************** */
+package org.squeryl.adapters
+
+import java.sql.SQLException
+
+import org.squeryl.dsl.CompositeKey
+import org.squeryl.dsl.ast.{ExpressionNode, QueryExpressionElements}
+import org.squeryl._
+import org.squeryl.internals._
+
+import scala.collection.mutable.ArrayBuffer
+
+class SQLiteAdapter extends DatabaseAdapter {
+
+  override def uuidTypeDeclaration = "uuid"
+  override def isFullOuterJoinSupported = false
+
+  override def writeColumnDeclaration(fmd: FieldMetaData, isPrimaryKey: Boolean, schema: Schema): String = {
+
+    var res = "  " + fmd.columnName + " " + databaseTypeFor(fmd)
+
+    for(d <- fmd.defaultValue) {
+      val v = convertToJdbcValue(d.value.asInstanceOf[AnyRef])
+      if(v.isInstanceOf[String])
+        res += " default '" + v + "'"
+      else
+        res += " default " + v 
+    }
+    
+    if(!fmd.isOption)
+      res += " not null"
+
+    if(isPrimaryKey)
+      res += " primary key"
+
+    if(supportsAutoIncrementInColumnDeclaration && fmd.isAutoIncremented)
+      res += " autoincrement"
+
+    res
+  }
+
+  override def writeCreateTable[T](t: Table[T], sw: StatementWriter, schema: Schema): Unit = {
+    sw.write("create table ")
+    sw.write(quoteName(t.prefixedName))
+    sw.write(" (\n")
+    sw.writeIndented {
+      sw.writeLinesWithSeparator(
+        t.posoMetaData.fieldsMetaData.map(
+          fmd => writeColumnDeclaration(fmd, fmd.declaredAsPrimaryKeyInSchema, schema)
+        ),
+        ","
+      )
+    }
+    val compositePrimaryKeys = _allCompositePrimaryKeys(t)
+    if (compositePrimaryKeys.nonEmpty) {
+      sw.write(", PRIMARY KEY (")
+      sw.write(compositePrimaryKeys map (_.columnName) mkString ", ")
+      sw.write(")")
+    }
+
+    sw.write(")")
+  }
+
+  private def _allCompositePrimaryKeys[T](t: Table[T]): Seq[FieldMetaData] = {
+    (t.ked map { ked =>
+      Utils.mapSampleObject(
+        t.asInstanceOf[Table[AnyRef]],
+        (z: AnyRef) => {
+          val id = ked.asInstanceOf[KeyedEntityDef[AnyRef, AnyRef]].getId(z)
+          id match {
+            case key: CompositeKey => key._fields
+            case _ => Seq.empty[FieldMetaData]
+          }
+
+        }
+      )
+    }) getOrElse Seq.empty[FieldMetaData]
+  }
+
+
+  override def intTypeDeclaration: String = "INTEGER"
+
+  override def longTypeDeclaration = "INTEGER"
+
+  override def supportsForeignKeyConstraints: Boolean = false
+
+  override def writeCompositePrimaryKeyConstraint(t: Table[_], cols: Iterable[FieldMetaData]): String =
+    s"SELECT * FROM sqlite_master WHERE 1 = 2"
+
+  override def writeDropTable(tableName: String): String = s"DROP TABLE IF EXISTS $tableName"
+
+  override def isTableDoesNotExistException(e: SQLException): Boolean =
+    e.getErrorCode == 42102
+
+  override def supportsCommonTableExpressions = false
+
+  override def writeEndOfQueryHint(isForUpdate: () => Boolean, qen: QueryExpressionElements, sw: StatementWriter) =
+    if(isForUpdate()) {
+      sw.pushPendingNextLine
+    }
+
+  override def writeRegexExpression(left: ExpressionNode, pattern: String, sw: StatementWriter) = {
+    sw.write("(")
+    left.write(sw)
+    sw.write(" LIKE ?)")
+    sw.addParam(ConstantStatementParam(InternalFieldMapper.stringTEF.createConstant(pattern)))
+  }
+}

--- a/src/test/scala/org/squeryl/sqlite/SQLiteTests.scala
+++ b/src/test/scala/org/squeryl/sqlite/SQLiteTests.scala
@@ -1,0 +1,100 @@
+package org.squeryl.sqlite
+
+import org.squeryl.test._
+
+import org.squeryl.framework.DBConnector
+import org.squeryl.adapters.SQLiteAdapter
+
+import org.squeryl.{AbstractSession, Session}
+import java.sql.Connection
+
+/*
+ * To run on command line : 
+ * 
+ * org.scalatest.tools.Runner -s org.squeryl.sqlite.SQLite_SchoolDb -eNDXEHLOW
+ * 
+ * org.scalatest.tools.Runner -s org.squeryl.sqlite.SQLite_SchoolDb -eNDXEHLOW -n SingleTestRun
+ * 
+ * */
+
+trait SQLite_ConnectionCommon extends DBConnector {
+  def connectToDbCommon(sessionFunc: Connection => AbstractSession) : Option[() => AbstractSession] = {
+    if(config.hasProps("sqlite.connectionString")){
+      Class.forName("org.sqlite.JDBC")
+      Some(() => {
+        val c = java.sql.DriverManager.getConnection(config.getProp("sqlite.connectionString"))
+        val s = sessionFunc(c)
+//        s.setLogger(println)
+        s
+      })
+    }else{
+      None
+    }
+  }
+}
+
+trait SQLite_Connection extends DBConnector with SQLite_ConnectionCommon {
+  def sessionCreator() : Option[() => AbstractSession] = connectToDbCommon(Session.create(_, new SQLiteAdapter))
+}
+
+
+trait SQLite_LazyConnection extends DBConnector with SQLite_ConnectionCommon {
+  def sessionCreator() : Option[() => AbstractSession] = connectToDbCommon(Session.create(_, new SQLiteAdapter))
+
+}
+
+/*
+ * Non-Lazy
+ */
+class SQLite_UuidTests extends UuidTests with SQLite_Connection
+class SQLite_NestedLeftOuterJoinTest extends NestedLeftOuterJoinTest with SQLite_Connection
+class SQLite_SchoolDbMutableRelations extends mutablerelations.SchoolDb2MetableRelations with SQLite_Connection
+class SQLite_TransactionTests extends TransactionTests with SQLite_Connection
+class SQLite_SchoolDb2 extends schooldb2.SchoolDb2Tests with SQLite_Connection
+class SQLite_SchoolDb extends schooldb.SchoolDbTestRun with SQLite_Connection {
+  override val ignoredTests = List(
+    "OptimisticCC1"
+  )
+}
+class SQLite_TestCustomTypesMode extends customtypes.TestCustomTypesMode with SQLite_Connection
+//TODO
+class SQLite_KickTheTires extends demo.KickTheTires with SQLite_Connection
+class SQLite_MusicDb extends musicdb.MusicDbTestRun with SQLite_Connection {
+  override val ignoredTests = List(
+    "UpperAndLowerFuncs"
+  )
+}
+class SQLite_LeftJoinTest extends LeftJoinTest with SQLite_Connection
+class SQLite_ConnectionClosing extends ConnectionClosingTest with SQLite_Connection {
+  def dbSpecificSelectNow: String = "select CURRENT_TIMESTAMP"
+}
+class SQLite_LogicalBooleanObjTests extends LogicalBooleanObjTests with SQLite_Connection
+
+class SQLite_CommonTableExpressions extends schooldb.CommonTableExpressions with SQLite_Connection
+
+/*
+* Lazy
+*/
+class SQLite_LazyUuidTests extends UuidTests with SQLite_LazyConnection
+class SQLite_LazyNestedLeftOuterJoinTest extends NestedLeftOuterJoinTest with SQLite_LazyConnection
+class SQLite_LazySchoolDbMutableRelations extends mutablerelations.SchoolDb2MetableRelations with SQLite_LazyConnection
+class SQLite_LazyTransactionTests extends TransactionTests with SQLite_LazyConnection
+class SQLite_LazySchoolDb2 extends schooldb2.SchoolDb2Tests with SQLite_LazyConnection
+class SQLite_LazySchoolDb extends schooldb.SchoolDbTestRun with SQLite_LazyConnection {
+  override val ignoredTests = List(
+    "OptimisticCC1"
+  )
+}
+class SQLite_LazyTestCustomTypesMode extends customtypes.TestCustomTypesMode with SQLite_LazyConnection
+class SQLite_LazyKickTheTires extends demo.KickTheTires with SQLite_LazyConnection
+class SQLite_LazyMusicDb extends musicdb.MusicDbTestRun with SQLite_LazyConnection {
+  override val ignoredTests = List(
+    "UpperAndLowerFuncs"
+  )
+}
+class SQLite_LazyLeftJoinTest extends LeftJoinTest with SQLite_LazyConnection
+class SQLite_LazyConnectionClosing extends ConnectionClosingTest with SQLite_LazyConnection {
+  def dbSpecificSelectNow: String = "select CURRENT_TIMESTAMP"
+}
+class SQLite_LazyLogicalBooleanObjTests extends LogicalBooleanObjTests with SQLite_LazyConnection
+

--- a/src/test/scala/org/squeryl/sqlite/SQLiteTests.scala
+++ b/src/test/scala/org/squeryl/sqlite/SQLiteTests.scala
@@ -24,7 +24,6 @@ trait SQLite_ConnectionCommon extends DBConnector {
       Some(() => {
         val c = java.sql.DriverManager.getConnection(config.getProp("sqlite.connectionString"))
         val s = sessionFunc(c)
-//        s.setLogger(println)
         s
       })
     }else{
@@ -57,9 +56,15 @@ class SQLite_SchoolDb extends schooldb.SchoolDbTestRun with SQLite_Connection {
   )
 }
 class SQLite_TestCustomTypesMode extends customtypes.TestCustomTypesMode with SQLite_Connection
-//TODO
-class SQLite_KickTheTires extends demo.KickTheTires with SQLite_Connection
+class SQLite_KickTheTires extends demo.KickTheTires with SQLite_Connection {
+  // This test generates a sentence with double parentheses after `in` clause
+  // In SQLite this causes that the query returns only one item
+  override val ignoredTests = List(
+    "kick tires"
+  )
+}
 class SQLite_MusicDb extends musicdb.MusicDbTestRun with SQLite_Connection {
+  // Regexp not supported
   override val ignoredTests = List(
     "UpperAndLowerFuncs"
   )
@@ -86,8 +91,15 @@ class SQLite_LazySchoolDb extends schooldb.SchoolDbTestRun with SQLite_LazyConne
   )
 }
 class SQLite_LazyTestCustomTypesMode extends customtypes.TestCustomTypesMode with SQLite_LazyConnection
-class SQLite_LazyKickTheTires extends demo.KickTheTires with SQLite_LazyConnection
+class SQLite_LazyKickTheTires extends demo.KickTheTires with SQLite_LazyConnection {
+  // This test generates a sentence with double parentheses after `in` clause
+  // In SQLite this causes that the query returns only one item
+  override val ignoredTests = List(
+    "kick tires"
+  )
+}
 class SQLite_LazyMusicDb extends musicdb.MusicDbTestRun with SQLite_LazyConnection {
+  // Regexp not supported
   override val ignoredTests = List(
     "UpperAndLowerFuncs"
   )
@@ -97,4 +109,3 @@ class SQLite_LazyConnectionClosing extends ConnectionClosingTest with SQLite_Laz
   def dbSpecificSelectNow: String = "select CURRENT_TIMESTAMP"
 }
 class SQLite_LazyLogicalBooleanObjTests extends LogicalBooleanObjTests with SQLite_LazyConnection
-


### PR DESCRIPTION
This PR brings support for SQLite engine. The special things here are:

* SQLite doesn't support to add constraints through `ALTER TABLE` [[1]](https://www.sqlite.org/omitted.html) so the composite keys is solved by:
 * Modifying the method `writeCreateTable` to create the composite keys in the `CREATE TABLE` statement
 * Creating an empty statement in method `writeCompositePrimaryKeyConstraint`. This is not elegant but I didn't find another way
* Removed `FOR UPDATE` sentence in `SELECT` in `writeEndOfQueryHint` method (not supported)
* Replaced body in `writeRegexExpression` method with something that compiles but the regular expressions are not supported in SQLite without adding user defined functions [[2]](http://stackoverflow.com/questions/24037982/how-used-regexp-in-sqlite)
* Ignored `"kick tires"` test because the generated statement has double parentheses and SQLite fails. I've sent a message to sqlite user group list [[3]](http://mailinglists.sqlite.org/cgi-bin/mailman/private/sqlite-users/2015-March/058482.html) (You need to register to see, can't find a public ticket manager)

Waiting for feedback