### PR TITLE
use StringBuilder instead of StringBuffer

### DIFF
--- a/src/main/scala/org/squeryl/dsl/Group.scala
+++ b/src/main/scala/org/squeryl/dsl/Group.scala
@@ -28,7 +28,7 @@ class GroupWithMeasures[K,M](k: K, m: M) {
   def measures = m
 
   override def toString = {
-    val sb = new StringBuffer
+    val sb = new java.lang.StringBuilder
     sb.append("GroupWithMeasures[")
     sb.append("key=")
     sb.append(key)

--- a/src/main/scala/org/squeryl/dsl/ast/ExpressionNode.scala
+++ b/src/main/scala/org/squeryl/dsl/ast/ExpressionNode.scala
@@ -523,7 +523,7 @@ trait QueryableExpressionNode extends ExpressionNode with UniqueIdInAliaseRequir
   def getOrCreateAllSelectElements(forScope: QueryExpressionElements): Iterable[SelectElement]
 
   def dumpAst = {
-    val sb = new StringBuffer
+    val sb = new java.lang.StringBuilder
     visitDescendants {(n,parent,d:Int) =>
       val c = 4 * d
       for(i <- 1 to c) sb.append(' ')

--- a/src/main/scala/org/squeryl/dsl/ast/QueryExpressionNode.scala
+++ b/src/main/scala/org/squeryl/dsl/ast/QueryExpressionNode.scala
@@ -93,7 +93,7 @@ class QueryExpressionNode[R](val _query: AbstractQuery[R],
   def getOrCreateSelectElement(fmd: FieldMetaData, forScope: QueryExpressionElements) = throw new UnsupportedOperationException("implement me")
 
   override def toString = {
-    val sb = new StringBuffer
+    val sb = new java.lang.StringBuilder
     sb.append('QueryExpressionNode + "[")
     if(_query.isRoot)
       sb.append("root:")

--- a/src/main/scala/org/squeryl/dsl/ast/ViewExpressionNode.scala
+++ b/src/main/scala/org/squeryl/dsl/ast/ViewExpressionNode.scala
@@ -79,7 +79,7 @@ class ViewExpressionNode[U](val view: View[U])
       sw.write(sw.quoteName(view.prefixedName))
 
   override def toString = {
-    val sb = new StringBuffer
+    val sb = new java.lang.StringBuilder
     sb.append('ViewExpressionNode +"[")
     sb.append(sample)
     sb.append("]:")

--- a/src/main/scala/org/squeryl/logging/BarChartRenderer.scala
+++ b/src/main/scala/org/squeryl/logging/BarChartRenderer.scala
@@ -75,7 +75,7 @@ object BarChartRenderer {
   """
 
   def funcCalls(stats: Seq[Stat]) = {
-    val sb = new StringBuffer
+    val sb = new java.lang.StringBuilder
     var i = 0
     for(s <- stats) {
       i += 1


### PR DESCRIPTION
http://docs.oracle.com/javase/8/docs/api/java/lang/StringBuffer.html

> The StringBuilder class should generally be used in preference to this one, as it supports all of the same operations but it is faster, as it performs no synchronization.