### PR TITLE
Syntax: ForUpdate after Pagination with Limit and Offset

### DIFF
--- a/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
+++ b/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
@@ -162,9 +162,9 @@ trait DatabaseAdapter {
       sw.pushPendingNextLine
     }
 
-    writeEndOfQueryHint(() => qen.isForUpdate, qen, sw)
-
     writePaginatedQueryDeclaration(() => qen.page, qen, sw)
+
+    writeEndOfQueryHint(() => qen.isForUpdate, qen, sw)
   }
 
   def writeUnionQueryOptions(qen: QueryExpressionElements, sw: StatementWriter): Unit = {

--- a/src/test/scala/org/squeryl/test/schooldb/SchoolDb.scala
+++ b/src/test/scala/org/squeryl/test/schooldb/SchoolDb.scala
@@ -1237,6 +1237,15 @@ abstract class SchoolDbTestRun extends SchoolDbTestBase {
     passed('testForUpdate)
   }
 
+  test("PaginatedForUpdate") {
+    val testInstance = sharedTestInstance; import testInstance._
+    val t = professors.where(p => p.id === tournesol.id).page(0, 1).forUpdate.single
+
+    assert(t.yearlySalary == 80.0, "expected 80.0, got " + t.yearlySalary)
+    assert(t.weight == Some(70.5), "expected Some(70.5), got " + t.weight)
+
+    passed('testForUpdate)
+  }
 
 
   test("PartialUpdate1") {


### PR DESCRIPTION
Fix the correct query syntax when using for update with pagination.

`...page(0, 1).forUpdate`

Wrong syntax:
```
...
FOR UPDATE
LIMIT 1 OFFSET 0
```
Correct syntax:
```
...
LIMIT 1 OFFSET 0
FOR UPDATE
```
