### PR TITLE
Cleaned up all the warn-unused and warn-unused-import issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ scalacOptions ++= Seq(
 )
 
 val unusedWarnings = Seq(
+  "-Xfatal-warnings",
   "-Ywarn-unused",
   "-Ywarn-unused-import"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,6 @@ scalacOptions ++= Seq(
 )
 
 val unusedWarnings = Seq(
-  "-Xfatal-warnings",
   "-Ywarn-unused",
   "-Ywarn-unused-import"
 )

--- a/src/main/scala/org/squeryl/KeyedEntity.scala
+++ b/src/main/scala/org/squeryl/KeyedEntity.scala
@@ -71,7 +71,7 @@ trait KeyedEntity[K] extends PersistenceStatus {
 
   def id: K
 
-  override def hashCode =
+  override def hashCode: Int =
     if(isPersisted)
       id.hashCode
     else
@@ -147,7 +147,7 @@ class ForeignKeyDeclaration(val idWithinSchema: Int, val foreignKeyColumnName: S
   private var _referentialActions: Option[(Option[ReferentialAction],Option[ReferentialAction])] = None
 
   private [squeryl] def _isActive =
-    _referentialActions != None
+    _referentialActions.isDefined
 
   private [squeryl] def _referentialAction1: Option[ReferentialAction] =
     _referentialActions.get._1
@@ -158,26 +158,26 @@ class ForeignKeyDeclaration(val idWithinSchema: Int, val foreignKeyColumnName: S
   /**
    * Causes the foreign key to have no constraint 
    */
-  def unConstrainReference()(implicit ev: Schema) =
+  def unConstrainReference(): Unit =
     _referentialActions = None
 
   /**
    * Will cause a foreign key constraint to be created at schema creation time :
    * alter table <tableOfForeignKey> add foreign key (<foreignKey>) references <tableOfPrimaryKey>(<primaryKey>)
    */
-  def constrainReference()(implicit ev: Schema) =
+  def constrainReference(): Unit =
     _referentialActions = Some((None, None))
 
   /**
    * Does the same as constrainReference, plus adds a ReferentialAction (ex.: foreignKeyDeclaration.constrainReference(onDelete cascade)) 
    */
-  def constrainReference(a1: ReferentialAction)(implicit ev: Schema) =
+  def constrainReference(a1: ReferentialAction): Unit =
     _referentialActions = Some((Some(a1), None))
 
   /**
    * Does the same as constrainReference, plus adds two ReferentialActions
    * (ex.: foreignKeyDeclaration.constrainReference(onDelete cascade, onUpdate restrict)) 
    */
-  def constrainReference(a1: ReferentialAction, a2: ReferentialAction)(implicit ev: Schema) =
+  def constrainReference(a1: ReferentialAction, a2: ReferentialAction): Unit =
     _referentialActions = Some((Some(a1), Some(a2)))
 }

--- a/src/main/scala/org/squeryl/Schema.scala
+++ b/src/main/scala/org/squeryl/Schema.scala
@@ -333,11 +333,7 @@ class Schema(implicit val fieldMapper: FieldMapper) {
    *  }
    *
    */
-  def columnTypeFor(fieldMetaData: FieldMetaData, owner: Table[_]): Option[String] = {
-    fieldMetaData.unused
-    owner.unused
-    None
-  }
+  def columnTypeFor(fieldMetaData: FieldMetaData, owner: Table[_]): Option[String] = None
   
   def tableNameFromClass(c: Class[_]):String =
     c.getSimpleName

--- a/src/main/scala/org/squeryl/Schema.scala
+++ b/src/main/scala/org/squeryl/Schema.scala
@@ -124,7 +124,7 @@ class Schema(implicit val fieldMapper: FieldMapper) {
 
     for(t <- _tables) {
       val sw = new StatementWriter(true, _dbAdapter)
-      _dbAdapter.writeCreateTable(t, sw, this)
+      _dbAdapter.writeCreateTable(t, sw)
       statementHandler(sw.statement + ";")
       _dbAdapter.postCreateTable(t, Some(statementHandler))
 
@@ -230,7 +230,7 @@ class Schema(implicit val fieldMapper: FieldMapper) {
 
     for(fk <- _activeForeignKeySpecs) {
       cs.connection.createStatement
-      dba.dropForeignKeyStatement(fk._1, dba.foreignKeyConstraintName(fk._1, fk._3.idWithinSchema), cs)
+      dba.dropForeignKeyStatement(fk._1, dba.foreignKeyConstraintName(fk._1, fk._3.idWithinSchema))
     }
   }
 
@@ -271,7 +271,7 @@ class Schema(implicit val fieldMapper: FieldMapper) {
   private def _createTables = {
     for(t <- _tables) {
       val sw = new StatementWriter(_dbAdapter)
-      _dbAdapter.writeCreateTable(t, sw, this)
+      _dbAdapter.writeCreateTable(t, sw)
       _executeDdl(sw.statement)
       _dbAdapter.postCreateTable(t, None)
       for(indexDecl <- _indexDeclarationsFor(t))
@@ -333,7 +333,11 @@ class Schema(implicit val fieldMapper: FieldMapper) {
    *  }
    *
    */
-  def columnTypeFor(fieldMetaData: FieldMetaData, owner: Table[_]): Option[String] = None
+  def columnTypeFor(fieldMetaData: FieldMetaData, owner: Table[_]): Option[String] = {
+    fieldMetaData.unused
+    owner.unused
+    None
+  }
   
   def tableNameFromClass(c: Class[_]):String =
     c.getSimpleName
@@ -472,18 +476,16 @@ class Schema(implicit val fieldMapper: FieldMapper) {
     // Validate that autoIncremented is not used on other fields than KeyedEntity[A].id :
     // since it is not yet unsupported :
     for(ca <- colAss) ca match {
-      case cga:CompositeKeyAttributeAssignment => {}
-      case caa:ColumnAttributeAssignment => {
-        for(ca <- caa.columnAttributes if ca.isInstanceOf[AutoIncremented] && !(caa.left.isIdFieldOfKeyedEntity))
+      case caa:ColumnAttributeAssignment =>
+        for(ca <- caa.columnAttributes if ca.isInstanceOf[AutoIncremented] && !caa.left.isIdFieldOfKeyedEntity)
           org.squeryl.internals.Utils.throwError("Field " + caa.left.nameOfProperty + " of table " + table.name +
-                " is declared as autoIncremented, auto increment is currently only supported on KeyedEntity[A].id")
-      }
-      case dva:Any => {}
+            " is declared as autoIncremented, auto increment is currently only supported on KeyedEntity[A].id")
+      case _ =>
     }
   }
 
-  private def _addColumnGroupAttributeAssignment(cga: ColumnGroupAttributeAssignment) =
-    _columnGroupAttributeAssignments.append(cga);
+  private def _addColumnGroupAttributeAssignment(cga: ColumnGroupAttributeAssignment): Unit =
+    _columnGroupAttributeAssignments.append(cga)
   
   def defaultColumnAttributesForKeyedEntityId(typeOfIdField: Class[_]) =
     if(typeOfIdField.isAssignableFrom(classOf[java.lang.Long]) || typeOfIdField.isAssignableFrom(classOf[java.lang.Integer]))
@@ -525,21 +527,6 @@ class Schema(implicit val fieldMapper: FieldMapper) {
 
   def callbacks: Seq[LifecycleEvent] = Nil
 
-////2.9.x approach for LyfeCycle events :
-//  def delayedInit(body: => Unit) = {
-//
-//    body
-//
-//    (for(cb <- callbacks; t <- cb.target) yield (t, cb))
-//    .groupBy(_._1)
-//    .mapValues(_.map(_._2))
-//    .foreach(
-//     (t:Tuple2[View[_],Seq[LifecycleEvent]]) => {
-//       t._1._callbacks = new LifecycleEventInvoker(t._2, t._1)
-//     }
-//    )
-//  }
-
 ////2.8.x approach for LyfeCycle events :
   private [squeryl] lazy val _callbacks: Map[View[_],LifecycleEventInvoker] = {
     val m =
@@ -568,10 +555,10 @@ class Schema(implicit val fieldMapper: FieldMapper) {
   protected def beforeUpdate[A]()(implicit m: Manifest[A]) =
     new LifecycleEventPercursorClass[A](m.runtimeClass, this, BeforeUpdate)
 
-  protected def beforeDelete[A](t: Table[A])(implicit ev : KeyedEntityDef[A,_]) =
+  protected def beforeDelete[A](t: Table[A]) =
     new LifecycleEventPercursorTable[A](t, BeforeDelete)
 
-  protected def beforeDelete[K, A]()(implicit m: Manifest[A], ked: KeyedEntityDef[A,K]) =
+  protected def beforeDelete[K, A]()(implicit m: Manifest[A]) =
     new LifecycleEventPercursorClass[A](m.runtimeClass, this, BeforeDelete)
    
   protected def afterSelect[A](t: Table[A]) =

--- a/src/main/scala/org/squeryl/View.scala
+++ b/src/main/scala/org/squeryl/View.scala
@@ -26,13 +26,9 @@ import java.sql.ResultSet
  */
 class View[T] private [squeryl](_name: String, private[squeryl] val classOfT: Class[T], schema: Schema, _prefix: Option[String], val ked: Option[KeyedEntityDef[T,_]]) extends Queryable[T] {
 
-
-//2.9.x approach for LyfeCycle events :
-//  private [squeryl] var _callbacks: PosoLifecycleEventListener = NoOpPosoLifecycleEventListener
-
 ////2.8.x approach for LyfeCycle events :
   private [squeryl] lazy val _callbacks =
-    schema._callbacks.get(this).getOrElse(NoOpPosoLifecycleEventListener)
+    schema._callbacks.getOrElse(this, NoOpPosoLifecycleEventListener)
 
 
   def name = schema.tableNameFromClassName(_name)
@@ -85,7 +81,7 @@ class View[T] private [squeryl](_name: String, private[squeryl] val classOfT: Cl
     if(o == null)
       o = _createInstanceOfRowObject
     
-    resultSetMapper.map(o, resultSet);
+    resultSetMapper.map(o, resultSet)
     val t = o.asInstanceOf[T]
     _setPersisted(t)
     _callbacks.afterSelect(t.asInstanceOf[AnyRef]).asInstanceOf[T]

--- a/src/main/scala/org/squeryl/adapters/DB2Adapter.scala
+++ b/src/main/scala/org/squeryl/adapters/DB2Adapter.scala
@@ -15,13 +15,13 @@
  ***************************************************************************** */
 package org.squeryl.adapters
 
-import org.squeryl.internals.{StatementWriter, DatabaseAdapter}
+import org.squeryl.internals.StatementWriter
 import org.squeryl.dsl.ast.ConstantTypedExpression
 import org.squeryl.{Session, Table}
 import java.sql.SQLException
 import org.squeryl.dsl.ast._
 
-class DB2Adapter extends DatabaseAdapter {
+class DB2Adapter extends GenericAdapter {
 
   override def booleanTypeDeclaration = "char(1)"
 
@@ -84,7 +84,7 @@ class DB2Adapter extends DatabaseAdapter {
     e.getErrorCode == -204
   }
 
-  override def writePaginatedQueryDeclaration(page: () => Option[(Int, Int)], qen: QueryExpressionElements, sw: StatementWriter) = {}
+  override def writePaginatedQueryDeclaration(page: () => Option[(Int, Int)], sw: StatementWriter) = {}
 
   override def writeQuery(qen: QueryExpressionElements, sw: StatementWriter) =
     if (qen.page == None)

--- a/src/main/scala/org/squeryl/adapters/DerbyAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/DerbyAdapter.scala
@@ -15,19 +15,18 @@
  ***************************************************************************** */
 package org.squeryl.adapters
 
-import org.squeryl.Schema
-import org.squeryl.internals.{StatementWriter, FieldMetaData, DatabaseAdapter}
+import org.squeryl.internals.{StatementWriter, FieldMetaData}
 import org.squeryl.dsl.ast._
 import java.sql.SQLException
 
-class DerbyAdapter extends DatabaseAdapter {
+class DerbyAdapter extends GenericAdapter {
 
   override def intTypeDeclaration = "integer"
   override def binaryTypeDeclaration = "blob(1M)"
 
   override def isFullOuterJoinSupported = false
 
-  override def writeColumnDeclaration(fmd: FieldMetaData, isPrimaryKey: Boolean, schema: Schema): String = {
+  override def writeColumnDeclaration(fmd: FieldMetaData, isPrimaryKey: Boolean): String = {
 
     var res = "  " + quoteIdentifier(fmd.columnName) + " " + databaseTypeFor(fmd)
 
@@ -51,7 +50,7 @@ class DerbyAdapter extends DatabaseAdapter {
     res
   }
 
-  override def writePaginatedQueryDeclaration(page: () => Option[(Int, Int)], qen: QueryExpressionElements, sw: StatementWriter) = {
+  override def writePaginatedQueryDeclaration(page: () => Option[(Int, Int)], sw: StatementWriter): Unit = {
     page().foreach(p => {
       sw.write("offset ")
       sw.write(p._1.toString)
@@ -62,11 +61,11 @@ class DerbyAdapter extends DatabaseAdapter {
     })
   }
   
-  override def isTableDoesNotExistException(e: SQLException) =
+  override def isTableDoesNotExistException(e: SQLException): Boolean =
     e.getSQLState == "42Y55"
 
-  override def writeRegexExpression(left: ExpressionNode, pattern: String, sw: StatementWriter) =
+  override def writeRegexExpression(left: ExpressionNode, pattern: String, sw: StatementWriter): Unit =
     throw new UnsupportedOperationException("Derby does not support a regex scalar function")
 
-  override def quoteIdentifier(s: String) = "\"" + s + "\""
+  override def quoteIdentifier(s: String): String = "\"" + s + "\""
 }

--- a/src/main/scala/org/squeryl/adapters/GenericAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/GenericAdapter.scala
@@ -1,0 +1,20 @@
+package org.squeryl.adapters
+
+import java.sql.SQLException
+
+import org.squeryl.Table
+import org.squeryl.dsl.ast.QueryExpressionElements
+import org.squeryl.internals.{DatabaseAdapter, StatementWriter}
+
+
+abstract class GenericAdapter extends DatabaseAdapter {
+
+  override def postCreateTable(t: Table[_], printSinkWhenWriteOnlyMode: Option[String => Unit]): Unit = {}
+
+  override def postDropTable(t: Table[_]): Unit = {}
+
+  override def isNotNullConstraintViolation(e: SQLException): Boolean = false
+
+  override def writeEndOfFromHint(qen: QueryExpressionElements, sw: StatementWriter): Unit = {}
+
+}

--- a/src/main/scala/org/squeryl/adapters/H2Adapter.scala
+++ b/src/main/scala/org/squeryl/adapters/H2Adapter.scala
@@ -15,16 +15,15 @@
  ***************************************************************************** */
 package org.squeryl.adapters
 
-import org.squeryl.Schema
 import java.sql.SQLException
-import org.squeryl.internals.{FieldMetaData, DatabaseAdapter}
+import org.squeryl.internals.FieldMetaData
 
-class H2Adapter extends DatabaseAdapter {
+class H2Adapter extends GenericAdapter {
 
   override def uuidTypeDeclaration = "uuid"
   override def isFullOuterJoinSupported = false
 
-  override def writeColumnDeclaration(fmd: FieldMetaData, isPrimaryKey: Boolean, schema: Schema): String = {
+  override def writeColumnDeclaration(fmd: FieldMetaData, isPrimaryKey: Boolean): String = {
 
     var res = "  " + fmd.columnName + " " + databaseTypeFor(fmd)
 

--- a/src/main/scala/org/squeryl/adapters/MySQLAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/MySQLAdapter.scala
@@ -17,12 +17,12 @@ package org.squeryl.adapters
 
 import org.squeryl.{ReferentialAction, Table}
 import java.sql.SQLException
-import org.squeryl.internals.{StatementWriter, DatabaseAdapter}
+import org.squeryl.internals.StatementWriter
 import org.squeryl.dsl.ast.ExpressionNode
 import org.squeryl.internals.ConstantStatementParam
 import org.squeryl.InternalFieldMapper
 
-class MySQLAdapter extends DatabaseAdapter {
+class MySQLAdapter extends GenericAdapter {
 
   override def isFullOuterJoinSupported = false
 

--- a/src/main/scala/org/squeryl/adapters/PostgreSqlAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/PostgreSqlAdapter.scala
@@ -18,10 +18,10 @@ package org.squeryl.adapters
 import org.squeryl.dsl.ast.FunctionNode
 import java.sql.{ResultSet, SQLException}
 import java.util.UUID
-import org.squeryl.internals.{StatementWriter, DatabaseAdapter, FieldMetaData}
+import org.squeryl.internals.{StatementWriter, FieldMetaData}
 import org.squeryl.{Session, Table}
 
-class PostgreSqlAdapter extends DatabaseAdapter {
+class PostgreSqlAdapter extends GenericAdapter {
 
   /**
    * NB: You can override `usePostgresSequenceNamingScheme` to return true in a

--- a/src/main/scala/org/squeryl/adapters/SQLiteAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/SQLiteAdapter.scala
@@ -18,16 +18,16 @@ package org.squeryl.adapters
 import java.sql.SQLException
 
 import org.squeryl.dsl.CompositeKey
-import org.squeryl.dsl.ast.{ExpressionNode, QueryExpressionElements}
+import org.squeryl.dsl.ast.ExpressionNode
 import org.squeryl._
 import org.squeryl.internals._
 
-class SQLiteAdapter extends DatabaseAdapter {
+class SQLiteAdapter extends GenericAdapter {
 
   override def uuidTypeDeclaration = "uuid"
   override def isFullOuterJoinSupported = false
 
-  override def writeColumnDeclaration(fmd: FieldMetaData, isPrimaryKey: Boolean, schema: Schema): String = {
+  override def writeColumnDeclaration(fmd: FieldMetaData, isPrimaryKey: Boolean): String = {
 
     var res = "  " + fmd.columnName + " " + databaseTypeFor(fmd)
 
@@ -51,14 +51,14 @@ class SQLiteAdapter extends DatabaseAdapter {
     res
   }
 
-  override def writeCreateTable[T](t: Table[T], sw: StatementWriter, schema: Schema): Unit = {
+  override def writeCreateTable[T](t: Table[T], sw: StatementWriter): Unit = {
     sw.write("create table ")
     sw.write(quoteName(t.prefixedName))
     sw.write(" (\n")
     sw.writeIndented {
       sw.writeLinesWithSeparator(
         t.posoMetaData.fieldsMetaData.map(
-          fmd => writeColumnDeclaration(fmd, fmd.declaredAsPrimaryKeyInSchema, schema)
+          fmd => writeColumnDeclaration(fmd, fmd.declaredAsPrimaryKeyInSchema)
         ),
         ","
       )
@@ -106,12 +106,12 @@ class SQLiteAdapter extends DatabaseAdapter {
 
   override def supportsCommonTableExpressions = false
 
-  override def writeEndOfQueryHint(isForUpdate: () => Boolean, qen: QueryExpressionElements, sw: StatementWriter) =
+  override def writeEndOfQueryHint(isForUpdate: () => Boolean, sw: StatementWriter): Unit =
     if(isForUpdate()) {
       sw.pushPendingNextLine
     }
 
-  override def writeRegexExpression(left: ExpressionNode, pattern: String, sw: StatementWriter) = {
+  override def writeRegexExpression(left: ExpressionNode, pattern: String, sw: StatementWriter): Unit = {
     sw.write("(")
     left.write(sw)
     sw.write(" LIKE ?)")

--- a/src/main/scala/org/squeryl/dsl/QueryDsl.scala
+++ b/src/main/scala/org/squeryl/dsl/QueryDsl.scala
@@ -873,14 +873,10 @@ trait QueryDsl
         ev9: A9 => TypedExpression[A9, _]) =
     new CompositeKey9[A1,A2,A3,A4,A5,A6,A7,A8,A9](t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
 
-  implicit def compositeKey2CanLookup[T <: CompositeKey](t: T): CanLookup = {
-    t.unused
+  implicit def compositeKey2CanLookup[T <: CompositeKey](t: T): CanLookup =
     CompositeKeyLookup
-  }
 
-  implicit def simpleKey2CanLookup[T](t: T)(implicit ev: T => TypedExpression[T, _]): CanLookup = {
-    t.unused
+  implicit def simpleKey2CanLookup[T](t: T)(implicit ev: T => TypedExpression[T, _]): CanLookup =
     new SimpleKeyLookup[T](ev)
-  }
 
 }

--- a/src/main/scala/org/squeryl/dsl/QueryDsl.scala
+++ b/src/main/scala/org/squeryl/dsl/QueryDsl.scala
@@ -72,10 +72,6 @@ trait QueryDsl
       
     }
   }
-  
-//  implicit def viewToIterable[R](t: View[R]): Iterable[R] = 
-//      queryToIterable(view2QueryAll(t))
-  
 
   def using[A](session: AbstractSession)(a: =>A): A =
     session.using(a _)
@@ -184,10 +180,10 @@ trait QueryDsl
   
   def not(b: LogicalBoolean) = new FunctionNode("not", Seq(b)) with LogicalBoolean
 
-  def upper[A1,T1](s: TypedExpression[A1,T1])(implicit f: TypedExpressionFactory[A1,T1], ev2: T1 <:< TOptionString) = 
+  def upper[A1,T1](s: TypedExpression[A1,T1])(implicit f: TypedExpressionFactory[A1,T1]): TypedExpressionConversion[A1, T1] =
     f.convert(new FunctionNode("upper", Seq(s)))
   
-  def lower[A1,T1](s: TypedExpression[A1,T1])(implicit f: TypedExpressionFactory[A1,T1], ev2: T1 <:< TOptionString) = 
+  def lower[A1,T1](s: TypedExpression[A1,T1])(implicit f: TypedExpressionFactory[A1,T1]): TypedExpressionConversion[A1, T1] =
     f.convert(new FunctionNode("lower", Seq(s)))
 
   def exists[A1](query: Query[A1]) = new ExistsExpression(query.copy(false, Nil).ast, "exists")
@@ -609,7 +605,7 @@ trait QueryDsl
     }
   }
 
-  def oneToManyRelation[O,M](ot: Table[O], mt: Table[M])(implicit kedO: KeyedEntityDef[O,_]) = new OneToManyRelationBuilder(ot,mt)
+  def oneToManyRelation[O,M](ot: Table[O], mt: Table[M]) = new OneToManyRelationBuilder(ot,mt)
 
   class OneToManyRelationBuilder[O,M](ot: Table[O], mt: Table[M]) {
     
@@ -877,16 +873,14 @@ trait QueryDsl
         ev9: A9 => TypedExpression[A9, _]) =
     new CompositeKey9[A1,A2,A3,A4,A5,A6,A7,A8,A9](t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
 
-  implicit def compositeKey2CanLookup[T <: CompositeKey](t: T): CanLookup = CompositeKeyLookup
+  implicit def compositeKey2CanLookup[T <: CompositeKey](t: T): CanLookup = {
+    t.unused
+    CompositeKeyLookup
+  }
 
-  implicit def simpleKey2CanLookup[T](t: T)(implicit ev: T => TypedExpression[T, _]): CanLookup = new SimpleKeyLookup[T](ev)
+  implicit def simpleKey2CanLookup[T](t: T)(implicit ev: T => TypedExpression[T, _]): CanLookup = {
+    t.unused
+    new SimpleKeyLookup[T](ev)
+  }
 
-  // Case statements :
-/*
-  def caseOf[A](expr: NumericalExpression[A]) = new CaseOfNumericalExpressionMatchStart(expr)
-
-  def caseOf[A](expr: NonNumericalExpression[A]) = new CaseOfNonNumericalExpressionMatchStart(expr)
-
-  def caseOf = new CaseOfConditionChainStart
-*/
 }

--- a/src/main/scala/org/squeryl/dsl/TypedExpression.scala
+++ b/src/main/scala/org/squeryl/dsl/TypedExpression.scala
@@ -18,7 +18,6 @@ package org.squeryl.dsl
 import org.squeryl.dsl.ast._
 import org.squeryl.internals._
 import org.squeryl.Session
-import org.squeryl.Schema
 import org.squeryl.internals.AttributeValidOnNumericalColumn
 import org.squeryl.Query
 import java.sql.ResultSet
@@ -101,8 +100,7 @@ trait TypedExpression[A1,T1] extends ExpressionNode {
 
   def div[T3 >: T1 <: TNumeric, T2 <: T3, A2, A3, A4, T4]
          (e: TypedExpression[A2,T2])
-         (implicit f:  TypedExpressionFactory[A3,T3], 
-                   tf: Floatifier[T3,A4,T4]): TypedExpression[A4,T4] = tf.floatify(new BinaryOperatorNode(this, e, "/"))
+         (implicit tf: Floatifier[T3,A4,T4]): TypedExpression[A4,T4] = tf.floatify(new BinaryOperatorNode(this, e, "/"))
 
   def +[T3 >: T1 <: TNumeric, T2 <: T3, A2, A3]
          (e: TypedExpression[A2,T2])
@@ -118,77 +116,80 @@ trait TypedExpression[A1,T1] extends ExpressionNode {
 
   def /[T3 >: T1 <: TNumeric, T2 <: T3, A2, A3, A4, T4]
          (e: TypedExpression[A2,T2])
-         (implicit f:  TypedExpressionFactory[A3,T3], 
-                   tf: Floatifier[T3,A4,T4]): TypedExpression[A4,T4] = tf.floatify(new BinaryOperatorNode(this, e, "/"))
+         (implicit tf: Floatifier[T3,A4,T4]): TypedExpression[A4,T4] = tf.floatify(new BinaryOperatorNode(this, e, "/"))
 
-  def ===[A2,T2](b: TypedExpression[A2,T2])(implicit ev: CanCompare[T1, T2]) = new EqualityExpression(this, b)
-  def <>[A2,T2](b: TypedExpression[A2,T2])(implicit ev: CanCompare[T1, T2]) = new BinaryOperatorNodeLogicalBoolean(this, b, "<>")
+  def ===[A2,T2](b: TypedExpression[A2,T2]) =
+    new EqualityExpression(this, b)
 
-  def isDistinctFrom[A2,T2](b: TypedExpression[A2,T2])(implicit ev: CanCompare[T1, T2]) = new BinaryOperatorNodeLogicalBoolean(this, b, "IS DISTINCT FROM")
-  def isNotDistinctFrom[A2,T2](b: TypedExpression[A2,T2])(implicit ev: CanCompare[T1, T2]) = new BinaryOperatorNodeLogicalBoolean(this, b, "IS NOT DISTINCT FROM")
-  
-  def ===[A2,T2](q: Query[Measures[A2]])(implicit tef: TypedExpressionFactory[A2,T2], ev: CanCompare[T1, T2]) = 
-    new BinaryOperatorNodeLogicalBoolean(this, q.copy(false, Nil).ast, "=")
+  def <>[A2,T2](b: TypedExpression[A2,T2]) =
+    new BinaryOperatorNodeLogicalBoolean(this, b, "<>")
 
-  def <>[A2,T2](q: Query[Measures[A2]])(implicit tef: TypedExpressionFactory[A2,T2], ev: CanCompare[T1, T2]) = 
-    new BinaryOperatorNodeLogicalBoolean(this, q.copy(false, Nil).ast, "<>")
-  
-  def gt[A2,T2](b: TypedExpression[A2,T2])(implicit ev: CanCompare[T1, T2]) = new BinaryOperatorNodeLogicalBoolean(this, b, ">")
-  def lt[A2,T2](b: TypedExpression[A2,T2])(implicit ev: CanCompare[T1, T2]) = new BinaryOperatorNodeLogicalBoolean(this, b, "<")
-  def gte[A2,T2](b: TypedExpression[A2,T2])(implicit ev: CanCompare[T1, T2]) = new BinaryOperatorNodeLogicalBoolean(this, b, ">=")
-  def lte[A2,T2](b: TypedExpression[A2,T2])(implicit ev: CanCompare[T1, T2]) = new BinaryOperatorNodeLogicalBoolean(this, b, "<=")
-  
-  def gt [A2,T2](q: Query[A2])(implicit cc: CanCompare[T1,T2]): LogicalBoolean = new BinaryOperatorNodeLogicalBoolean(this, q.copy(false, Nil).ast, ">")
-  def gte[A2,T2](q: Query[A2])(implicit cc: CanCompare[T1,T2]): LogicalBoolean = new BinaryOperatorNodeLogicalBoolean(this, q.copy(false, Nil).ast, ">=")
-  def lt [A2,T2](q: Query[A2])(implicit cc: CanCompare[T1,T2]): LogicalBoolean = new BinaryOperatorNodeLogicalBoolean(this, q.copy(false, Nil).ast, "<")
-  def lte[A2,T2](q: Query[A2])(implicit cc: CanCompare[T1,T2]): LogicalBoolean = new BinaryOperatorNodeLogicalBoolean(this, q.copy(false, Nil).ast, "<=")  
-  
-  def > [A2,T2](q: Query[A2])(implicit cc: CanCompare[T1,T2]): LogicalBoolean = gt(q)
-  def >=[A2,T2](q: Query[A2])(implicit cc: CanCompare[T1,T2]): LogicalBoolean = gte(q)
-  def < [A2,T2](q: Query[A2])(implicit cc: CanCompare[T1,T2]): LogicalBoolean = lt(q)
-  def <=[A2,T2](q: Query[A2])(implicit cc: CanCompare[T1,T2]): LogicalBoolean = lte(q)
+  def isDistinctFrom[A2,T2](b: TypedExpression[A2,T2]) =
+    new BinaryOperatorNodeLogicalBoolean(this, b, "IS DISTINCT FROM")
 
-  def >[A2,T2](b: TypedExpression[A2,T2])(implicit ev: CanCompare[T1, T2]) = gt(b)
-  def <[A2,T2](b: TypedExpression[A2,T2])(implicit ev: CanCompare[T1, T2]) = lt(b)
-  def >=[A2,T2](b: TypedExpression[A2,T2])(implicit ev: CanCompare[T1, T2]) = gte(b)
-  def <=[A2,T2](b: TypedExpression[A2,T2])(implicit ev: CanCompare[T1, T2]) = lte(b)
+  def isNotDistinctFrom[A2,T2](b: TypedExpression[A2,T2]) =
+    new BinaryOperatorNodeLogicalBoolean(this, b, "IS NOT DISTINCT FROM")
+  
+  def ===[A2,T2](q: Query[Measures[A2]]) =
+    new BinaryOperatorNodeLogicalBoolean(this, q.copy(asRoot = false, Nil).ast, "=")
+
+  def <>[A2,T2](q: Query[Measures[A2]]) =
+    new BinaryOperatorNodeLogicalBoolean(this, q.copy(asRoot = false, Nil).ast, "<>")
+  
+  def gt[A2,T2](b: TypedExpression[A2,T2]) = new BinaryOperatorNodeLogicalBoolean(this, b, ">")
+  def lt[A2,T2](b: TypedExpression[A2,T2]) = new BinaryOperatorNodeLogicalBoolean(this, b, "<")
+  def gte[A2,T2](b: TypedExpression[A2,T2]) = new BinaryOperatorNodeLogicalBoolean(this, b, ">=")
+  def lte[A2,T2](b: TypedExpression[A2,T2]) = new BinaryOperatorNodeLogicalBoolean(this, b, "<=")
+  
+  def gt [A2,T2](q: Query[A2]): LogicalBoolean = new BinaryOperatorNodeLogicalBoolean(this, q.copy(asRoot = false, Nil).ast, ">")
+  def gte[A2,T2](q: Query[A2]): LogicalBoolean = new BinaryOperatorNodeLogicalBoolean(this, q.copy(asRoot = false, Nil).ast, ">=")
+  def lt [A2,T2](q: Query[A2]): LogicalBoolean = new BinaryOperatorNodeLogicalBoolean(this, q.copy(asRoot = false, Nil).ast, "<")
+  def lte[A2,T2](q: Query[A2]): LogicalBoolean = new BinaryOperatorNodeLogicalBoolean(this, q.copy(asRoot = false, Nil).ast, "<=")
+  
+  def > [A2,T2](q: Query[A2]): LogicalBoolean = gt(q)
+  def >=[A2,T2](q: Query[A2]): LogicalBoolean = gte(q)
+  def < [A2,T2](q: Query[A2]): LogicalBoolean = lt(q)
+  def <=[A2,T2](q: Query[A2]): LogicalBoolean = lte(q)
+
+  def >[A2,T2](b: TypedExpression[A2,T2]): BinaryOperatorNodeLogicalBoolean = gt(b)
+  def <[A2,T2](b: TypedExpression[A2,T2]): BinaryOperatorNodeLogicalBoolean = lt(b)
+  def >=[A2,T2](b: TypedExpression[A2,T2]): BinaryOperatorNodeLogicalBoolean = gte(b)
+  def <=[A2,T2](b: TypedExpression[A2,T2]): BinaryOperatorNodeLogicalBoolean = lte(b)
   
   //TODO: add T1 <:< TOption to isNull and isNotNull 
   def isNull= new PostfixOperatorNode("is null", this) with LogicalBoolean
   def isNotNull= new PostfixOperatorNode("is not null", this) with LogicalBoolean
   
   def between[A2,T2,A3,T3](b1: TypedExpression[A2,T2], 
-                           b2: TypedExpression[A3,T3])
-                          (implicit ev1: CanCompare[T1, T2], 
-                                    ev2: CanCompare[T2, T3]) = new BetweenExpression(this, b1, b2)
+                           b2: TypedExpression[A3,T3]) = new BetweenExpression(this, b1, b2)
   
-  def like[A2,T2 <: TOptionString](s: TypedExpression[A2,T2])(implicit ev: CanCompare[T1,T2]) = new BinaryOperatorNodeLogicalBoolean(this, s, "like")
+  def like[A2,T2 <: TOptionString](s: TypedExpression[A2,T2]) = new BinaryOperatorNodeLogicalBoolean(this, s, "like")
   
-  def ilike[A2,T2 <: TOptionString](s: TypedExpression[A2,T2])(implicit ev: CanCompare[T1,T2]) = new BinaryOperatorNodeLogicalBoolean(this, s, "ilike")
+  def ilike[A2,T2 <: TOptionString](s: TypedExpression[A2,T2]) = new BinaryOperatorNodeLogicalBoolean(this, s, "ilike")
 
   def ||[A2,T2](e: TypedExpression[A2,T2]) = new ConcatOp[A1,A2,T1,T2](this, e)
     
   def regex(pattern: String) = new FunctionNode(pattern, Seq(this)) with LogicalBoolean {
 
-    override def doWrite(sw: StatementWriter) =
+    override def doWrite(sw: StatementWriter): Unit =
       Session.currentSession.databaseAdapter.writeRegexExpression(outer, pattern, sw)
   }
   
-  def is(columnAttributes: AttributeValidOnNumericalColumn*)(implicit restrictUsageWithinSchema: Schema) =
+  def is(columnAttributes: AttributeValidOnNumericalColumn*) =
     new ColumnAttributeAssignment(_fieldMetaData, columnAttributes)
   
   
-  def in[A2,T2](t: Traversable[A2])(implicit cc: CanCompare[T1,T2]): LogicalBoolean =  
-    new InclusionOperator(this, new RightHandSideOfIn(new ConstantExpressionNodeList(t, mapper)).toIn)  
+  def in[A2,T2](t: Traversable[A2]): LogicalBoolean =
+    new InclusionOperator(this, new RightHandSideOfIn(new ConstantExpressionNodeList(t)).toIn)
   
-  def in[A2,T2](q: Query[A2])(implicit cc: CanCompare[T1,T2]): LogicalBoolean =
-    new InclusionOperator(this, new RightHandSideOfIn(q.copy(false, Nil).ast))
+  def in[A2,T2](q: Query[A2]): LogicalBoolean =
+    new InclusionOperator(this, new RightHandSideOfIn(q.copy(asRoot = false, Nil).ast))
   
-  def notIn[A2,T2](t: Traversable[A2])(implicit cc: CanCompare[T1,T2]): LogicalBoolean =  
-    new ExclusionOperator(this, new RightHandSideOfIn(new ConstantExpressionNodeList(t, mapper)).toNotIn)
+  def notIn[A2,T2](t: Traversable[A2]): LogicalBoolean =
+    new ExclusionOperator(this, new RightHandSideOfIn(new ConstantExpressionNodeList(t)).toNotIn)
   
-  def notIn[A2,T2](q: Query[A2])(implicit cc: CanCompare[T1,T2]): LogicalBoolean =
-    new ExclusionOperator(this, new RightHandSideOfIn(q.copy(false, Nil).ast))
+  def notIn[A2,T2](q: Query[A2]): LogicalBoolean =
+    new ExclusionOperator(this, new RightHandSideOfIn(q.copy(asRoot = false, Nil).ast))
   
   def ~ = this
 
@@ -215,9 +216,8 @@ trait TypedExpression[A1,T1] extends ExpressionNode {
         this.asInstanceOf[SelectElementReference[_,_]]
       }
       catch { // TODO: validate this at compile time with a scalac plugin
-        case e:ClassCastException => {
-            throw new RuntimeException("left side of assignment '" + Utils.failSafeString(this.toString)+ "' is invalid, make sure statement uses *only* closure argument.", e)
-        }
+        case e:ClassCastException =>
+          throw new RuntimeException("left side of assignment '" + Utils.failSafeString(this.toString)+ "' is invalid, make sure statement uses *only* closure argument.", e)
       }
 
     val fmd =
@@ -225,9 +225,8 @@ trait TypedExpression[A1,T1] extends ExpressionNode {
         ser.selectElement.asInstanceOf[FieldSelectElement].fieldMetaData
       }
       catch { // TODO: validate this at compile time with a scalac plugin
-        case e:ClassCastException => {
+        case e:ClassCastException =>
           throw new RuntimeException("left side of assignment '" + Utils.failSafeString(this.toString)+ "' is invalid, make sure statement uses *only* closure argument.", e)
-        }
       }
     fmd
   }
@@ -238,11 +237,11 @@ class TypedExpressionConversion[A1,T1](val e: ExpressionNode, bf: TypedExpressio
   
   def mapper: OutMapper[A1] = bf.createOutMapper
   
-  override def inhibited = e.inhibited
+  override def inhibited: Boolean = e.inhibited
 
-  override def doWrite(sw: StatementWriter) = e.doWrite((sw))
+  override def doWrite(sw: StatementWriter): Unit = e.doWrite(sw)
 
-  override def children = e.children  
+  override def children: List[ExpressionNode] = e.children
 }
 
 trait Floatifier[T1,A2,T2] {
@@ -377,7 +376,7 @@ trait DeOptionizer[P1, A1, T1, A2 >: Option[A1] <: Option[A1], T2] extends JdbcM
 }
 
 class ConcatOp[A1,A2,T1,T2](val a1: TypedExpression[A1,T1], val a2: TypedExpression[A2,T2]) extends BinaryOperatorNode(a1,a2, "||") {
-  override def doWrite(sw: StatementWriter) =
+  override def doWrite(sw: StatementWriter): Unit =
       sw.databaseAdapter.writeConcatOperator(a1, a2, sw)   
 }
 
@@ -385,8 +384,8 @@ class ConcatOp[A1,A2,T1,T2](val a1: TypedExpression[A1,T1], val a2: TypedExpress
 class NvlNode[A,T](e1: TypedExpression[_,_], e2: TypedExpression[A,T]) 
   extends BinaryOperatorNode(e1,e2,"nvl", false) with TypedExpression[A,T] {
 
-   def mapper = e2.mapper
+   def mapper: OutMapper[A] = e2.mapper
 
-   override def doWrite(sw: StatementWriter) =
+   override def doWrite(sw: StatementWriter): Unit =
     sw.databaseAdapter.writeNvlCall(left, right, sw)         
 }

--- a/src/main/scala/org/squeryl/dsl/ast/ExpressionNode.scala
+++ b/src/main/scala/org/squeryl/dsl/ast/ExpressionNode.scala
@@ -303,10 +303,10 @@ class CompositeKeyAttributeAssignment(val group: CompositeKey, _columnAttributes
 
   override def isIdFieldOfKeyedEntity = {
     val fmdHead = group._fields.head
-    fmdHead.parentMetaData.viewOrTable.ked.map(_.idPropertyName == group._propertyName).getOrElse(false)
+    fmdHead.parentMetaData.viewOrTable.ked.exists(_.idPropertyName == group._propertyName)
   }
 
-  assert(group._propertyName != None)
+  assert(group._propertyName.isDefined)
 
   override def name:Option[String] = group._propertyName
 }
@@ -374,7 +374,7 @@ class ConstantTypedExpression[A1,T1](val value: A1, val nativeJdbcValue: AnyRef,
   override def toString = 'ConstantTypedExpression + ":" + value
 }
 
-class ConstantExpressionNodeList[T](val value: Traversable[T], mapper: OutMapper[_]) extends ExpressionNode {
+class ConstantExpressionNodeList[T](val value: Traversable[T]) extends ExpressionNode {
 
   def isEmpty =
     value == Nil

--- a/src/main/scala/org/squeryl/dsl/fsm/StartState.scala
+++ b/src/main/scala/org/squeryl/dsl/fsm/StartState.scala
@@ -61,11 +61,9 @@ trait WhereState[Cond]
   def select[R](yieldClosure: =>R): SelectState[R] =
     new BaseQueryYield[R](this, yieldClosure _)
 
-  def set(updateAssignments: UpdateAssignment*)(implicit cond: Cond =:= Conditioned) =
-    new UpdateStatement(whereClause, updateAssignments)
+  def set(updateAssignments: UpdateAssignment*) = new UpdateStatement(whereClause, updateAssignments)
   
-  def setAll(updateAssignments: UpdateAssignment*)(implicit cond: Cond =:= Unconditioned) =
-    new UpdateStatement(whereClause, updateAssignments)    
+  def setAll(updateAssignments: UpdateAssignment*) = new UpdateStatement(whereClause, updateAssignments)
 }
 
 trait HavingState[G]

--- a/src/main/scala/org/squeryl/internals/FieldReferenceLinker.scala
+++ b/src/main/scala/org/squeryl/internals/FieldReferenceLinker.scala
@@ -257,7 +257,7 @@ object FieldReferenceLinker {
 		  if(!visited.containsKey(o)) {
 			  val clazz = o.getClass
 			  val clazzName = clazz.getName
-			  //println("Looking at " + clazzName)
+
 			  if(!clazzName.startsWith("java.") && 
 					  !clazzName.startsWith("net.sf.cglib.") && 
 					  !clazzName.startsWith("scala.Enumeration")) {

--- a/src/main/scala/org/squeryl/internals/ResultSetMapper.scala
+++ b/src/main/scala/org/squeryl/internals/ResultSetMapper.scala
@@ -159,8 +159,7 @@ class ColumnToTupleMapper(val outMappers: Array[OutMapper[_]]) {
       case 20 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs), m(15).map(rs), m(16).map(rs), m(17).map(rs), m(18).map(rs), m(19).map(rs))
       case 21 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs), m(15).map(rs), m(16).map(rs), m(17).map(rs), m(18).map(rs), m(19).map(rs), m(20).map(rs))
       case 22 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs), m(15).map(rs), m(16).map(rs), m(17).map(rs), m(18).map(rs), m(19).map(rs), m(20).map(rs), m(21).map(rs))
-
-      case z:Any => org.squeryl.internals.Utils.throwError("tuples of size "+size+" and greater are not supported")
+      case _ => org.squeryl.internals.Utils.throwError(s"tuples of size $size and greater are not supported")
     }
     
     res.asInstanceOf[T]

--- a/src/main/scala/org/squeryl/internals/Utils.scala
+++ b/src/main/scala/org/squeryl/internals/Utils.scala
@@ -16,11 +16,14 @@
 package org.squeryl.internals
 
 import java.sql.{ResultSet, SQLException, Statement}
+
 import org.squeryl.dsl.boilerplate.Query1
 import org.squeryl.Queryable
 import org.squeryl.dsl.fsm.QueryElements
-import org.squeryl.dsl.ast.{QueryExpressionElements, LogicalBoolean}
+import org.squeryl.dsl.ast.{LogicalBoolean, QueryExpressionElements}
 import java.sql.Connection
+
+import scala.util.Try
 
 object Utils {
 
@@ -36,25 +39,21 @@ object Utils {
   def failSafeString(s: =>String, valueOnFail: String) =
     _failSafeString(s _, valueOnFail)
 
-  private def _failSafeString(s: ()=>String, valueOnFail: String) =
-    try {
-      s()
-    }
-    catch {
-      case e:Exception => valueOnFail
-    }
+  private def _failSafeString(s: () => String, valueOnFail: String): String =
+    Try(s()).getOrElse(valueOnFail)
+
 
   def close(s: Statement) =
     try {s.close}
-    catch {case e:SQLException => {}}
+    catch {case _:SQLException => {}}
 
   def close(rs: ResultSet) =
     try {rs.close}
-    catch {case e:SQLException => {}}
+    catch {case _:SQLException => {}}
 
   def close(c: Connection) =
     try {c.close}
-    catch {case e:SQLException => {}}
+    catch {case _:SQLException => {}}
     
   private class DummyQueryElements[Cond](override val whereClause: Option[()=>LogicalBoolean]) extends QueryElements[Cond]
   

--- a/src/main/scala/org/squeryl/logging/BarChartRenderer.scala
+++ b/src/main/scala/org/squeryl/logging/BarChartRenderer.scala
@@ -1,6 +1,5 @@
 package org.squeryl.logging
 
-import xml.Unparsed
 import java.io.{FileOutputStream, PrintStream}
 import org.squeryl.InternalFieldMapper._
 
@@ -94,8 +93,9 @@ object BarChartRenderer {
     sb.toString
    }
 
-
-  def page(stats: Stat*) = """
+  def page(stats: Stat*) = {
+    stats.unused
+    """
     <html xmlns="http://www.w3.org/1999/xhtml">
       <head>
         <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
@@ -123,5 +123,6 @@ object BarChartRenderer {
       </body>
     </html>
     """
+  }
 
 }

--- a/src/main/scala/org/squeryl/logging/BarChartRenderer.scala
+++ b/src/main/scala/org/squeryl/logging/BarChartRenderer.scala
@@ -7,17 +7,14 @@ object BarChartRenderer {
 
   class Stat(val title: String, val xAxisLabel: String, val lines: Iterable[StatLine], measureFromLike: StatLine => String) {
 
-    def queryLabelsJSArray =
+    def queryLabelsJSArray: String =
       lines.map(sl => "'" + sl.statement.definitionOrCallSite + "'").mkString("[",",","]")
 
-    def measuresJSArray =
+    def measuresJSArray: String =
       lines.map(measureFromLike(_)).mkString("[",",","]")
   }
 
-  def generateStatSummary(staticHtmlFile: java.io.File, n: Int) = {
-
-
-
+  def generateStatSummary(staticHtmlFile: java.io.File, n: Int): Unit = {
     val page =
       BarChartRenderer.page(
         new Stat(
@@ -31,7 +28,7 @@ object BarChartRenderer {
           StatsSchema.topRankingStatements(n, Measure.InvocationCount),
           sl => sl.invocationCount.toString),
         new Stat(
-          "Top "+n+" statements incurring most cummulative execution time",
+          "Top "+n+" statements incurring most cumulative execution time",
           "cummulative execution time",
           StatsSchema.topRankingStatements(n, Measure.CumulativeExecutionTime),
           sl => sl.cumulativeExecutionTime.toString),
@@ -44,7 +41,7 @@ object BarChartRenderer {
 
     val ps = new PrintStream(new FileOutputStream(staticHtmlFile))
     ps.print(page)
-    ps.close
+    ps.close()
   }
 
   val drawFunc = """
@@ -73,7 +70,7 @@ object BarChartRenderer {
     }
   """
 
-  def funcCalls(stats: Seq[Stat]) = {
+  def funcCalls(stats: Seq[Stat]): String = {
     val sb = new java.lang.StringBuilder
     var i = 0
     for(s <- stats) {
@@ -93,9 +90,8 @@ object BarChartRenderer {
     sb.toString
    }
 
-  def page(stats: Stat*) = {
-    stats.unused
-    """
+  def page(stats: Stat*): String = {
+    s"""
     <html xmlns="http://www.w3.org/1999/xhtml">
       <head>
         <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
@@ -106,10 +102,10 @@ object BarChartRenderer {
         </script>
         <script type="text/javascript">
 
-          {Unparsed(drawFunc)}
+          {Unparsed($drawFunc)}
 
           function drawVisualization() {{
-            {Unparsed(funcCalls(stats))}
+            {Unparsed(${funcCalls(stats)})}
           }}
 
           google.setOnLoadCallback(drawVisualization);

--- a/src/main/scala/org/squeryl/logging/LocalH2SinkStatisticsListener.scala
+++ b/src/main/scala/org/squeryl/logging/LocalH2SinkStatisticsListener.scala
@@ -72,7 +72,7 @@ class LocalH2SinkStatisticsListener(val h2Session: AbstractSession) extends Stat
   }
 
   def resultSetIterationEnded(invocationId: String, iterationEndTime: Long, rowCount: Int, iterationCompleted: Boolean) = _pushOp {
-    StatsSchema.recordEndOfIteration(invocationId, iterationEndTime: Long, rowCount: Int, iterationCompleted: Boolean)
+    StatsSchema.recordEndOfIteration(invocationId, iterationEndTime: Long, rowCount: Int)
     h2Session.connection.commit
   }
 

--- a/src/main/scala/org/squeryl/logging/StatsSchema.scala
+++ b/src/main/scala/org/squeryl/logging/StatsSchema.scala
@@ -122,7 +122,7 @@ object StatsSchema extends Schema {
     si.id
   }
 
-  def recordEndOfIteration(statementInvocationId: String, iterationEndTime: Long, rowCount: Int, iterationCompleted: Boolean) = {
+  def recordEndOfIteration(statementInvocationId: String, iterationEndTime: Long, rowCount: Int) = {
 
     update(statementInvocations)(si =>
       where(si.id === statementInvocationId)

--- a/src/main/scala/org/squeryl/logging/UsageProfileConsolidator.scala
+++ b/src/main/scala/org/squeryl/logging/UsageProfileConsolidator.scala
@@ -31,11 +31,11 @@ object UsageProfileConsolidator {
       val (dst, src) = args.map(new java.io.File(_)).splitAt(1)
 
       val notExists = src.filterNot(_.exists)
-      if(notExists.size > 0)
+      if(notExists.length > 0)
         org.squeryl.internals.Utils.throwError("Files don't exist : \n" + notExists.mkString(",\n"))
 
 
-      Class.forName("org.h2.Driver");
+      Class.forName("org.h2.Driver")
 
       val dstDb = new Session(
         java.sql.DriverManager.getConnection("jdbc:h2:" + dst.head.getAbsolutePath, "sa", ""),
@@ -53,7 +53,7 @@ object UsageProfileConsolidator {
               (StatsSchema.statementInvocations.allRows, StatsSchema.statements.allRows)
             }
 
-          val stmtsToInsert = statements.filter(stmt => StatsSchema.statements.lookup(stmt.id) == None)
+          val stmtsToInsert = statements.filter(stmt => StatsSchema.statements.lookup(stmt.id).isEmpty)
           StatsSchema.statements.insert(stmtsToInsert)
 
           StatsSchema.statementInvocations.insert(invocations)
@@ -63,7 +63,7 @@ object UsageProfileConsolidator {
     }
 
 
-  def printUsage = {
+  def printUsage(): Unit = {
     println("Usage : ")
     println("java org.squeryl.logging.UsageProfileConsolidator <h2FileForConsolidatedStatsProfile> <list of h2 files to consolidate>")
   }

--- a/src/main/scala/org/squeryl/package.scala
+++ b/src/main/scala/org/squeryl/package.scala
@@ -1,9 +1,0 @@
-package org
-
-package object squeryl {
-
-  implicit class IdOps[A](a: A) {
-    def unused: Unit = ()
-  }
-
-}

--- a/src/main/scala/org/squeryl/package.scala
+++ b/src/main/scala/org/squeryl/package.scala
@@ -1,0 +1,9 @@
+package org
+
+package object squeryl {
+
+  implicit class IdOps[A](a: A) {
+    def unused: Unit = ()
+  }
+
+}

--- a/src/test/scala/org/squeryl/framework/QueryTester.scala
+++ b/src/test/scala/org/squeryl/framework/QueryTester.scala
@@ -14,16 +14,16 @@ trait QueryTester extends Matchers {
 
   var doNotExecute = false
 
-  def activateWorkbenchMode = {
+  def activateWorkbenchMode(): Unit = {
     logQueries = true
     dumpAst = true
     validateFirstAndExit = 0
   }
 
-  def loggerOn =
+  def loggerOn(): Unit =
     Session.currentSession.setLogger((s:String) => println(s))
 
-  def log(queryName: Symbol, query:Query[_]) = {
+  def log(queryName: Symbol, query:Query[_]): Unit = {
 
     println(queryName + " :")
     println(query)
@@ -35,8 +35,8 @@ trait QueryTester extends Matchers {
   def assertEquals[E](expected:E, actual:E, s:Symbol): Unit =
     assertEquals(expected, actual, s.toString)
 
-  def assertEquals[E](expected:E, actual:E, msg:String): Unit = {
-    actual should equal(expected)
+  def assertEquals[E](expected:E, actual:E, msg:String): Unit = withClue(msg) {
+    actual shouldBe expected
   }
 
   def validateQuery[R,S](name: Symbol, q:Query[R], mapFunc: R=>S, expected: List[S]): Unit =
@@ -46,9 +46,6 @@ trait QueryTester extends Matchers {
 
     if(validateFirstAndExit >= 1)
       return
-
-//    if(dumpAst)
-//      println(q.dumpAst)
 
     if(logFirst || logQueries)
       log(name, q)
@@ -60,23 +57,11 @@ trait QueryTester extends Matchers {
 
     r should equal(expected)
 
-//    if(r == expected)
-//      println("query " + name + " passed.")
-//    else {
-//      val msg =
-//        "query : " + name + " failed,\n" +
-//        "expected " + expected + " got " + r + " \n query " + name +
-//        " was : \n" + q
-//      org.squeryl.internals.Utils.org.squeryl.internals.Utils.throwError(msg)
-//    }
-
     if(validateFirstAndExit >= 0)
       validateFirstAndExit += 1
   }
 
-  def passed(s: Symbol) = {} //println(s )
+  def passed(s: Symbol): Unit = println(s)
 }
-
-
 
 object SingleTestRun extends org.scalatest.Tag("SingleTestRun")

--- a/src/test/scala/org/squeryl/test/TransactionTests.scala
+++ b/src/test/scala/org/squeryl/test/TransactionTests.scala
@@ -51,7 +51,7 @@ abstract class TransactionTests extends DbTestBase {
         doSomething(true)
       }
       catch {
-        case e: Exception => {}
+        case _: Exception =>
       }
 
       // fails with "no session exception"

--- a/src/test/scala/org/squeryl/test/musicdb/MusicDb.scala
+++ b/src/test/scala/org/squeryl/test/musicdb/MusicDb.scala
@@ -512,7 +512,7 @@ abstract class MusicDbTestRun extends SchemaTester with QueryTester with RunTest
         passed('testUpperAndLowerFuncs)
     }
     catch {
-      case e: UnsupportedOperationException => println("testUpperAndLowerFuncs: regex not supported by database adapter")
+      case _: UnsupportedOperationException => println("testUpperAndLowerFuncs: regex not supported by database adapter")
     }
   }
 

--- a/src/test/scala/org/squeryl/test/schooldb/SchoolDb.scala
+++ b/src/test/scala/org/squeryl/test/schooldb/SchoolDb.scala
@@ -1898,7 +1898,7 @@ abstract class Issue14 extends DbTestBase with QueryTester {
         val seqName = (new OracleAdapter).createSequenceName(Issue14Schema.professors.posoMetaData.findFieldMetaDataForProperty("id").get)
         try {stmt.execute("create sequence " + seqName)}
         catch {
-          case e:SQLException => {} 
+          case _: SQLException =>
         }
       }
       transaction {

--- a/src/test/scala/org/squeryl/test/schooldb2/SchoolDb2.scala
+++ b/src/test/scala/org/squeryl/test/schooldb2/SchoolDb2.scala
@@ -435,7 +435,7 @@ abstract class SchoolDb2Tests extends SchemaTester with RunTestsInsideTransactio
       physicsCourse.professors.associate(professeurTournesol)
     }
     catch {
-      case e:RuntimeException => {
+      case _: RuntimeException => {
         exceptionThrown = true
         sp.foreach(s.connection.rollback(_))
       }


### PR DESCRIPTION
The change is a pure cleanup change (no functional changes) to fix the problems reported by the unused checks (-Ywarn-unused and -Ywarn-unused-import) and enforcing the checks by adding -Xfatal-warnings (will result in a compilation error should any new unused code section be introduced). 

In some cases (where the method is a public one and can be overriden by the client) in order not to break the API removing the warning required marking the parameter explicitly as unused based on a solution proposed here: https://stackoverflow.com/questions/46128561/excluding-type-evidence-parameters-from-analysis-in-scala-when-using-ywarn-unus
