### PR TITLE
Fix the several typos detected by github.com/client9/misspell

### DIFF
--- a/src/main/scala/org/squeryl/Schema.scala
+++ b/src/main/scala/org/squeryl/Schema.scala
@@ -315,7 +315,7 @@ class Schema(implicit val fieldMapper: FieldMapper) {
    * Use this method to override the DatabaseAdapter's default column type for the given field
    * (FieldMetaData), returning None means that no override will take place.
    *
-   * There are two levels at which db column type can be overriden, in order of precedence :
+   * There are two levels at which db column type can be overridden, in order of precedence :
    *
    *   on(professors)(p => declare(
    *      s.yearlySalary is(dbType("real"))

--- a/src/main/scala/org/squeryl/Session.scala
+++ b/src/main/scala/org/squeryl/Session.scala
@@ -81,7 +81,7 @@ class LazySession(val connectionFunc: () => Connection, val databaseAdapter: Dat
         } catch {
           case e: SQLException => {
             Utils.close(connection)
-            if (txOk) throw e // if an exception occured b4 the commit/rollback we don't want to obscure the original exception
+            if (txOk) throw e // if an exception occurred b4 the commit/rollback we don't want to obscure the original exception
           }
         }
         try {
@@ -89,7 +89,7 @@ class LazySession(val connectionFunc: () => Connection, val databaseAdapter: Dat
             connection.close
         } catch {
           case e: SQLException => {
-            if (txOk) throw e // if an exception occured b4 the close we don't want to obscure the original exception
+            if (txOk) throw e // if an exception occurred b4 the close we don't want to obscure the original exception
           }
         }
       }
@@ -149,7 +149,7 @@ class Session(val connection: Connection, val databaseAdapter: DatabaseAdapter, 
       } catch {
         case e: SQLException => {
           Utils.close(connection)
-          if (txOk) throw e // if an exception occured b4 the commit/rollback we don't want to obscure the original exception
+          if (txOk) throw e // if an exception occurred b4 the commit/rollback we don't want to obscure the original exception
         }
       }
       try {
@@ -157,7 +157,7 @@ class Session(val connection: Connection, val databaseAdapter: DatabaseAdapter, 
           connection.close
       } catch {
         case e: SQLException => {
-          if (txOk) throw e // if an exception occured b4 the close we don't want to obscure the original exception
+          if (txOk) throw e // if an exception occurred b4 the close we don't want to obscure the original exception
         }
       }
     }

--- a/src/main/scala/org/squeryl/Table.scala
+++ b/src/main/scala/org/squeryl/Table.scala
@@ -153,7 +153,7 @@ class Table[T] private [squeryl] (n: String, c: Class[T], val schema: Schema, _p
             if(b == 0) {
               val updateOrInsert = if(isInsert) "insert" else "update"
               throw new StaleUpdateException(
-                "Attemped to "+updateOrInsert+" stale object under optimistic concurrency control")
+                "Attempted to "+updateOrInsert+" stale object under optimistic concurrency control")
             }
       }
       finally {

--- a/src/main/scala/org/squeryl/adapters/OracleAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/OracleAdapter.scala
@@ -180,7 +180,7 @@ class OracleAdapter extends DatabaseAdapter {
     for(p <- possibilities if !scope.contains(p))
       return p
 
-    if(s.length == padLength) // at this point 's' is completely 'random like', not helpfull to add it in the error message
+    if(s.length == padLength) // at this point 's' is completely 'random like', not helpful to add it in the error message
       throw new CouldNotShrinkIdentifierException
 
     makeUniqueInScope(s, scope, padLength + 1)

--- a/src/main/scala/org/squeryl/adapters/PostgreSqlAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/PostgreSqlAdapter.scala
@@ -114,7 +114,7 @@ class PostgreSqlAdapter extends DatabaseAdapter {
   }
 
   /**
-   * In the case custom DB type used it is benefitial to explicitly cast value to its type, because it invokes
+   * In the case custom DB type used it is beneficial to explicitly cast value to its type, because it invokes
    * proper cast function. For example, it is possible to insert Scala String into a DB ENUM using dbType.
    */
   override protected def writeValue(o: AnyRef, fmd: FieldMetaData, sw: StatementWriter): String =

--- a/src/main/scala/org/squeryl/dsl/ManyToMany.scala
+++ b/src/main/scala/org/squeryl/dsl/ManyToMany.scala
@@ -156,7 +156,7 @@ trait ManyToMany[O,A] extends Query[O] {
   /**
    * Creates a new association object 'a' and calls associate(o,a)
    *
-   * Note that this method will fail if the association object has NOT NULL constraint fields appart from the
+   * Note that this method will fail if the association object has NOT NULL constraint fields apart from the
    * foreign keys in the relations
    *  
    */

--- a/src/main/scala/org/squeryl/dsl/ast/SelectElement.scala
+++ b/src/main/scala/org/squeryl/dsl/ast/SelectElement.scala
@@ -323,7 +323,7 @@ class ExportedSelectElement
   /**
    * A root level query that has nested queries (or refers to queries in an outer scope) will
    * have SelectElements that are ExportedSelectElement, the 'actualSelectElement' points directly
-   * to the refered AST node, while 'target' refers to it indirectly (see target)
+   * to the referred AST node, while 'target' refers to it indirectly (see target)
    */
   override def actualSelectElement: SelectElement =
     selectElement.actualSelectElement

--- a/src/main/scala/org/squeryl/internals/FieldMetaData.scala
+++ b/src/main/scala/org/squeryl/internals/FieldMetaData.scala
@@ -134,7 +134,7 @@ class FieldMetaData(
   def defaultValue: Option[ConstantTypedExpression[_,_]] = _defaultValue
 
   /**
-   * The db column type declaration overriden in the schema, if None, it means that it is the default value for
+   * The db column type declaration overridden in the schema, if None, it means that it is the default value for
    * the adapter (see Correspondance of field types to database column types http://squeryl.org/schema-definition.html)  
    */
   def explicitDbTypeDeclaration: Option[String] = {
@@ -156,7 +156,7 @@ class FieldMetaData(
    * if it is defined, or the default length for Java primitive types.
    * The unit of the length is dependent on the type, the convention is
    * that numeric types have a length in byte, boolean is bits
-   * date has -1, and for string the lenght is in chars.  
+   * date has -1, and for string the length is in chars.  
    * double,long -> 8, float,int -> 4, byte -> 1, boolean -> 1
    * java.util.Date -> -1.
    *
@@ -235,7 +235,7 @@ class FieldMetaData(
    * 
    * <pre>
    * on(myKeyedEntityTable)(t =>declare(
-   *   id.is(autoIncremented)  // omiting primaryKey here has no effect, it is equivalent as id.is(primaryKey,autoIncremented)
+   *   id.is(autoIncremented)  // omitting primaryKey here has no effect, it is equivalent as id.is(primaryKey,autoIncremented)
    * ))
    * </pre>
    */

--- a/src/main/scala/org/squeryl/internals/FieldReferenceLinker.scala
+++ b/src/main/scala/org/squeryl/internals/FieldReferenceLinker.scala
@@ -195,7 +195,7 @@ object FieldReferenceLinker {
    * It is assumed that yield invocation for inspection will never be nested, since
    * a query is completely built (and it's yield inspection is done) before it can
    * be nested, this is unlikely to change, but documenting this assumption was
-   * deemed usefull, because this method would stop working (without complaining)
+   * deemed useful, because this method would stop working (without complaining)
    * if (the assumption) was broken.   
    */
 

--- a/src/main/scala/org/squeryl/internals/StatementWriter.scala
+++ b/src/main/scala/org/squeryl/internals/StatementWriter.scala
@@ -26,7 +26,7 @@ trait StatementParam
 case class ConstantStatementParam(p: ConstantTypedExpression[_,_]) extends StatementParam
 case class FieldStatementParam(v: AnyRef, fmd: FieldMetaData) extends StatementParam
 /*
- * ParamWithMapper is a workadound to accomodate the ConstantExpressionNodeList, ideally 'in' and 'notIn' would grab the TEF in scope :
+ * ParamWithMapper is a workadound to accommodate the ConstantExpressionNodeList, ideally 'in' and 'notIn' would grab the TEF in scope :
  * 
  * def in[A2,T2](t: Traversable[A2])(implicit cc: CanCompare[T1,T2], tef: TypedExpressionFactory[A2,T2]): LogicalBoolean =  
  *   new InclusionOperator(this, new RightHandSideOfIn(new zConstantExpressionNodeList(t, mapper)).toIn)

--- a/src/test/scala/org/squeryl/framework/RunTestsInsideTransaction.scala
+++ b/src/test/scala/org/squeryl/framework/RunTestsInsideTransaction.scala
@@ -12,7 +12,7 @@ trait RunTestsInsideTransaction extends DbTestBase {
       super.runTest(testName, args)
     else {
       // each test occur from within a transaction, that way when the test completes _all_ changes
-      // made during the test are reverted so each test gets a clean enviroment to test against
+      // made during the test are reverted so each test gets a clean environment to test against
       transaction {
         val res = super.runTest(testName, args)
 

--- a/src/test/scala/org/squeryl/test/TransactionTests.scala
+++ b/src/test/scala/org/squeryl/test/TransactionTests.scala
@@ -107,7 +107,7 @@ abstract class TransactionTests extends DbTestBase {
    }    
    
    val sf2  = new SessionFactory {
-     def newSession: AbstractSession = Utils.throwError("inner inTransaction sould not be started")
+     def newSession: AbstractSession = Utils.throwError("inner inTransaction should not be started")
    }
    
    

--- a/src/test/scala/org/squeryl/test/demo/MusicDb.scala
+++ b/src/test/scala/org/squeryl/test/demo/MusicDb.scala
@@ -141,7 +141,7 @@ object MusicDb extends Schema {
   val playlistElements = table[PlaylistElement]
   val ratings = table[Rating]
 
-  // drop (schema) is normaly protected... for safety, here we live dangerously !
+  // drop (schema) is normally protected... for safety, here we live dangerously !
   override def drop = super.drop
 }
 

--- a/src/test/scala/org/squeryl/test/schooldb2/SchoolDb2.scala
+++ b/src/test/scala/org/squeryl/test/schooldb2/SchoolDb2.scala
@@ -411,7 +411,7 @@ abstract class SchoolDb2Tests extends SchemaTester with RunTestsInsideTransactio
     }
 
     if(! exceptionThrown)
-      org.squeryl.internals.Utils.throwError('testUniquenessConstraint + " failed, unique constraint violation occured")
+      org.squeryl.internals.Utils.throwError('testUniquenessConstraint + " failed, unique constraint violation occurred")
 
     courseAssignments.Count.toLong shouldBe 1
   }


### PR DESCRIPTION
This pull request fixes the typos in this repository. Although I am not a native English speaker, [misspell](https://github.com/client9/misspell) detected obvious mistakes for us. I've fixed them except for false positives.

```
$ misspell .
src/main/scala/org/squeryl/Session.scala:84:49: "occured" is a misspelling of "occurred"
src/main/scala/org/squeryl/Session.scala:92:49: "occured" is a misspelling of "occurred"
src/main/scala/org/squeryl/Session.scala:152:47: "occured" is a misspelling of "occurred"
src/main/scala/org/squeryl/Session.scala:160:47: "occured" is a misspelling of "occurred"
src/main/scala/org/squeryl/Table.scala:156:17: "Attemped" is a misspelling of "Attempted"
src/main/scala/org/squeryl/Schema.scala:318:57: "overriden" is a misspelling of "overridden"
src/main/scala/org/squeryl/adapters/PostgreSqlAdapter.scala:117:43: "benefitial" is a misspelling of "beneficial"
src/main/scala/org/squeryl/adapters/OracleAdapter.scala:183:84: "helpfull" is a misspelling of "helpful"
src/main/scala/org/squeryl/dsl/ManyToMany.scala:159:94: "appart" is a misspelling of "apart"
src/main/scala/org/squeryl/dsl/ast/SelectElement.scala:326:12: "refered" is a misspelling of "referred"
src/main/scala/org/squeryl/internals/FieldMetaData.scala:137:36: "overriden" is a misspelling of "overridden"
src/main/scala/org/squeryl/internals/FieldMetaData.scala:159:37: "lenght" is a misspelling of "length"
src/main/scala/org/squeryl/internals/FieldMetaData.scala:238:34: "omiting" is a misspelling of "omitting"
src/main/scala/org/squeryl/internals/FieldReferenceLinker.scala:198:12: "usefull" is a misspelling of "useful"
src/main/scala/org/squeryl/internals/StatementWriter.scala:29:38: "accomodate" is a misspelling of "accommodate"
src/test/scala/org/squeryl/framework/RunTestsInsideTransaction.scala:15:69: "enviroment" is a misspelling of "environment"
src/test/scala/org/squeryl/test/TransactionTests.scala:110:77: "sould" is a misspelling of "could"
src/test/scala/org/squeryl/test/demo/MusicDb.scala:144:22: "normaly" is a misspelling of "normally"
src/test/scala/org/squeryl/test/schooldb2/SchoolDb2.scala:414:111: "occured" is a misspelling of "occurred"
```