### PR TITLE
MySQLAdapter overrides quoteIdentifier

### DIFF
--- a/src/main/scala/org/squeryl/adapters/MySQLAdapter.scala
+++ b/src/main/scala/org/squeryl/adapters/MySQLAdapter.scala
@@ -112,4 +112,6 @@ class MySQLAdapter extends DatabaseAdapter {
     right.write(sw)
     sw.write(")")
   }
+  
+  override def quoteIdentifier(s: String) = "`" + s + "`"
 }


### PR DESCRIPTION
Hi everybody,

I've just spotted a minor issue using MySQL. In particular, Squeryl is not quoting identifiers (table names, columns, etc).

In order to reproduce the issue, just create a table named `check`. You will see SQL exceptions since it is a reserved keyword.

### Small issue, easy fix. 

In this MR, `MySQLAdapter` just overrides `DatabaseAdapter.quoteIdentifier` appling the proper quotation.

### Test

I published a SNAPSHOT locally and tested it in a project I'm working on. I didn't add any unit/integration tests, so please help me understanding if they are necessary in this case and where to put them.

Thank you