### PR TITLE
Prepare scala 3 migration

### DIFF
--- a/src/main/scala/org/squeryl/Schema.scala
+++ b/src/main/scala/org/squeryl/Schema.scala
@@ -617,7 +617,7 @@ class Schema(implicit val fieldMapper: FieldMapper) {
   class ActiveRecord[A](a: A, queryDsl: QueryDsl, m: Manifest[A]) {
     
     private def _performAction(action: (Table[A]) => Unit) =
-      _tableTypes get (m.runtimeClass) map { table: Table[_] =>
+      _tableTypes get (m.runtimeClass) map { (table: Table[_]) =>
         queryDsl inTransaction (action(table.asInstanceOf[Table[A]]))
       }
     

--- a/src/main/scala/org/squeryl/Schema.scala
+++ b/src/main/scala/org/squeryl/Schema.scala
@@ -19,7 +19,7 @@ import dsl._
 import ast._
 import internals._
 
-import reflect.Manifest
+import reflect.ClassTag
 import java.sql.SQLException
 import java.io.PrintWriter
 import java.util.regex.Pattern
@@ -338,19 +338,19 @@ class Schema(implicit val fieldMapper: FieldMapper) {
   def tableNameFromClass(c: Class[_]):String =
     c.getSimpleName
 
-  protected def table[T]()(implicit manifestT: Manifest[T], ked: OptionalKeyedEntityDef[T,_]): Table[T] =
-    table(tableNameFromClass(manifestT.runtimeClass))(manifestT, ked)
+  protected def table[T]()(implicit ClassTagT: ClassTag[T], ked: OptionalKeyedEntityDef[T,_]): Table[T] =
+    table(tableNameFromClass(ClassTagT.runtimeClass))(ClassTagT, ked)
   
-  protected def table[T](name: String)(implicit manifestT: Manifest[T], ked: OptionalKeyedEntityDef[T,_]): Table[T] = {
-    val typeT = manifestT.runtimeClass.asInstanceOf[Class[T]]
+  protected def table[T](name: String)(implicit ClassTagT: ClassTag[T], ked: OptionalKeyedEntityDef[T,_]): Table[T] = {
+    val typeT = ClassTagT.runtimeClass.asInstanceOf[Class[T]]
     val t = new Table[T](name, typeT, this, None, ked.keyedEntityDef)
     _addTable(t)
     _addTableType(typeT, t)
     t
   }
 
-  protected def table[T](name: String, prefix: String)(implicit manifestT: Manifest[T], ked: OptionalKeyedEntityDef[T,_]): Table[T] = {
-    val typeT = manifestT.runtimeClass.asInstanceOf[Class[T]]
+  protected def table[T](name: String, prefix: String)(implicit ClassTagT: ClassTag[T], ked: OptionalKeyedEntityDef[T,_]): Table[T] = {
+    val typeT = ClassTagT.runtimeClass.asInstanceOf[Class[T]]
     val t = new Table[T](name, typeT, this, Some(prefix), ked.keyedEntityDef)
     _addTable(t)
     _addTableType(typeT, t)
@@ -559,43 +559,43 @@ class Schema(implicit val fieldMapper: FieldMapper) {
   protected def beforeInsert[A](t: Table[A]) =
     new LifecycleEventPercursorTable[A](t, BeforeInsert)
 
-  protected def beforeInsert[A]()(implicit m: Manifest[A]) =
+  protected def beforeInsert[A]()(implicit m: ClassTag[A]) =
     new LifecycleEventPercursorClass[A](m.runtimeClass, this, BeforeInsert)
 
   protected def beforeUpdate[A](t: Table[A]) =
     new LifecycleEventPercursorTable[A](t, BeforeUpdate)
 
-  protected def beforeUpdate[A]()(implicit m: Manifest[A]) =
+  protected def beforeUpdate[A]()(implicit m: ClassTag[A]) =
     new LifecycleEventPercursorClass[A](m.runtimeClass, this, BeforeUpdate)
 
   protected def beforeDelete[A](t: Table[A])(implicit ev : KeyedEntityDef[A,_]) =
     new LifecycleEventPercursorTable[A](t, BeforeDelete)
 
-  protected def beforeDelete[K, A]()(implicit m: Manifest[A], ked: KeyedEntityDef[A,K]) =
+  protected def beforeDelete[K, A]()(implicit m: ClassTag[A], ked: KeyedEntityDef[A,K]) =
     new LifecycleEventPercursorClass[A](m.runtimeClass, this, BeforeDelete)
    
   protected def afterSelect[A](t: Table[A]) =
     new LifecycleEventPercursorTable[A](t, AfterSelect)
     
-  protected def afterSelect[A]()(implicit m: Manifest[A]) =
+  protected def afterSelect[A]()(implicit m: ClassTag[A]) =
     new LifecycleEventPercursorClass[A](m.runtimeClass, this, AfterSelect)
 
   protected def afterInsert[A](t: Table[A]) =
     new LifecycleEventPercursorTable[A](t, AfterInsert)
 
-  protected def afterInsert[A]()(implicit m: Manifest[A]) =
+  protected def afterInsert[A]()(implicit m: ClassTag[A]) =
     new LifecycleEventPercursorClass[A](m.runtimeClass, this, AfterInsert)
 
   protected def afterUpdate[A](t: Table[A]) =
     new LifecycleEventPercursorTable[A](t, AfterUpdate)
 
-  protected def afterUpdate[A]()(implicit m: Manifest[A]) =
+  protected def afterUpdate[A]()(implicit m: ClassTag[A]) =
     new LifecycleEventPercursorClass[A](m.runtimeClass, this, AfterUpdate)
 
   protected def afterDelete[A](t: Table[A]) =
     new LifecycleEventPercursorTable[A](t, AfterDelete)
 
-  protected def afterDelete[A]()(implicit m: Manifest[A]) =
+  protected def afterDelete[A]()(implicit m: ClassTag[A]) =
     new LifecycleEventPercursorClass[A](m.runtimeClass, this, AfterDelete)
 
   protected def factoryFor[A](table: Table[A]) =
@@ -607,14 +607,14 @@ class Schema(implicit val fieldMapper: FieldMapper) {
    *
    * @return a instance of ActiveRecord associated to the given object.
    */
-  implicit def anyRef2ActiveTransaction[A](a: A)(implicit queryDsl: QueryDsl, m: Manifest[A]) =
+  implicit def anyRef2ActiveTransaction[A](a: A)(implicit queryDsl: QueryDsl, m: ClassTag[A]) =
     new ActiveRecord(a, queryDsl, m)
 
   /**
    * Active Record pattern implementation. Enables the user to insert an object in its
    * existent table with a convenient {{{save}}} method.
    */
-  class ActiveRecord[A](a: A, queryDsl: QueryDsl, m: Manifest[A]) {
+  class ActiveRecord[A](a: A, queryDsl: QueryDsl, m: ClassTag[A]) {
     
     private def _performAction(action: (Table[A]) => Unit) =
       _tableTypes get (m.runtimeClass) map { (table: Table[_]) =>

--- a/src/main/scala/org/squeryl/dsl/QueryDsl.scala
+++ b/src/main/scala/org/squeryl/dsl/QueryDsl.scala
@@ -21,7 +21,7 @@ import fsm._
 import org.squeryl.internals._
 import org.squeryl._
 import java.sql.{SQLException, ResultSet}
-
+import reflect.ClassTag
 
 trait BaseQueryDsl {
   implicit def noneKeyedEntityDef[A,K]: OptionalKeyedEntityDef[A,K] = new OptionalKeyedEntityDef[A,K] {
@@ -39,7 +39,7 @@ trait QueryDsl
   with BaseQueryDsl {
   outerQueryDsl =>
   
-  implicit def kedForKeyedEntities[A,K](implicit ev: A <:< KeyedEntity[K], m:Manifest[A]): KeyedEntityDef[A,K] = new KeyedEntityDef[A,K] {
+  implicit def kedForKeyedEntities[A,K](implicit ev: A <:< KeyedEntity[K], m:ClassTag[A]): KeyedEntityDef[A,K] = new KeyedEntityDef[A,K] {
     def getId(a:A) = a.id
     def isPersisted(a:A) = a.isPersisted
     def idPropertyName = "id"
@@ -378,8 +378,8 @@ trait QueryDsl
       kedL: KeyedEntityDef[L,_],
       kedR: KeyedEntityDef[R,_]) {
 
-    def via[A](f: (L,R,A)=>Tuple2[EqualityExpression,EqualityExpression])(implicit manifestA: Manifest[A], schema: Schema, kedA: KeyedEntityDef[A,_]) = {
-      val m2m = new ManyToManyRelationImpl(l,r,manifestA.runtimeClass.asInstanceOf[Class[A]], f, schema, nameOverride, kedL, kedR, kedA)
+    def via[A](f: (L,R,A)=>Tuple2[EqualityExpression,EqualityExpression])(implicit ClassTagA: ClassTag[A], schema: Schema, kedA: KeyedEntityDef[A,_]) = {
+      val m2m = new ManyToManyRelationImpl(l,r,ClassTagA.runtimeClass.asInstanceOf[Class[A]], f, schema, nameOverride, kedL, kedR, kedA)
       schema._addTable(m2m)
       m2m
     }

--- a/src/main/scala/org/squeryl/dsl/ast/ExpressionNode.scala
+++ b/src/main/scala/org/squeryl/dsl/ast/ExpressionNode.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.squeryl.internals._
 import org.squeryl.dsl._
 import org.squeryl.Session
+import reflect.ClassTag
 
 trait ExpressionNode {
 
@@ -68,11 +69,11 @@ trait ExpressionNode {
     _filterDescendants(this, new ArrayBuffer[ExpressionNode], predicate)
 
 
-  def filterDescendantsOfType[T](implicit manifest: Manifest[T]) =
+  def filterDescendantsOfType[T](implicit ClassTag: ClassTag[T]) =
     _filterDescendants(
       this,
       new ArrayBuffer[ExpressionNode],
-      (n:ExpressionNode)=> manifest.runtimeClass.isAssignableFrom(n.getClass)
+      (n:ExpressionNode)=> ClassTag.runtimeClass.isAssignableFrom(n.getClass)
     ).asInstanceOf[Iterable[T]]
 
   /**
@@ -270,10 +271,10 @@ trait BaseColumnAttributeAssignment {
 
   def columnAttributes: collection.Seq[ColumnAttribute]
 
-  def hasAttribute[A <: ColumnAttribute](implicit m: Manifest[A]) =
+  def hasAttribute[A <: ColumnAttribute](implicit m: ClassTag[A]) =
     findAttribute[A](m) != None
 
-  def findAttribute[A <: ColumnAttribute](implicit m: Manifest[A]) =
+  def findAttribute[A <: ColumnAttribute](implicit m: ClassTag[A]) =
     columnAttributes.find(ca => m.runtimeClass.isAssignableFrom(ca.getClass))
 }
 

--- a/src/main/scala/org/squeryl/internals/FieldMetaData.scala
+++ b/src/main/scala/org/squeryl/internals/FieldMetaData.scala
@@ -62,7 +62,7 @@ class FieldMetaData(
     if(sampleValue == null)
       org.squeryl.internals.Utils.throwError("classes with Enumerations must have a zero param constructor that assigns a sample to the enumeration field")
     else
-      enumeration flatMap { e: Enumeration =>
+      enumeration flatMap { (e: Enumeration) =>
         e.values find { _.id == id }
       } get
 

--- a/src/main/scala/org/squeryl/pg/PgSchema.scala
+++ b/src/main/scala/org/squeryl/pg/PgSchema.scala
@@ -3,20 +3,21 @@ package org.squeryl.pg
 import org.squeryl._
 import internals.{StatementWriter, FieldMapper}
 import dsl.ast.{ViewExpressionNode, ExpressionNode}
+import reflect.ClassTag
 
 class PgSchema(implicit fieldMapper: FieldMapper)
     extends Schema()(fieldMapper) {
 
-  protected def srf[T]()(implicit man: Manifest[T]): (Seq[ExpressionNode] => View[T]) =
+  protected def srf[T]()(implicit man: ClassTag[T]): (Seq[ExpressionNode] => View[T]) =
     srf(tableNameFromClass(man.runtimeClass))(man)
 
-  protected def srf[T](name: String)(implicit man: Manifest[T]): (Seq[ExpressionNode] => View[T]) =
+  protected def srf[T](name: String)(implicit man: ClassTag[T]): (Seq[ExpressionNode] => View[T]) =
     srf0(name, None, _: _*)
 
-  protected def srf[T](name: String, prefix: String)(implicit man: Manifest[T]): (Seq[ExpressionNode] => View[T]) =
+  protected def srf[T](name: String, prefix: String)(implicit man: ClassTag[T]): (Seq[ExpressionNode] => View[T]) =
     srf0(name, Some(prefix), _: _*)
 
-  private def srf0[T](name: String, prefix: Option[String], args: ExpressionNode*)(implicit man: Manifest[T]): View[T] = {
+  private def srf0[T](name: String, prefix: Option[String], args: ExpressionNode*)(implicit man: ClassTag[T]): View[T] = {
     val typeT = man.runtimeClass.asInstanceOf[Class[T]]
     new SrfView[T](name, typeT, this, prefix, args)
   }


### PR DESCRIPTION
The first step is to run the migrate plugin's `migrate-syntax` command and to replace the use of `Manifest` (that won't be available in scala 3) by `ClassTag`.

This is an attempt to break done the huge https://github.com/squeryl/squeryl/pull/296 into smaller chunks.

@xuwei-k are you willing to merge PRs working towards bringing support for scala 3 to squeryl? 