### PR TITLE
Prepare scala 3 migration (3)

### DIFF
--- a/src/main/scala/org/squeryl/PrimitiveTypeMode.scala
+++ b/src/main/scala/org/squeryl/PrimitiveTypeMode.scala
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2010 Maxime Lévesque
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,220 +29,220 @@ object PrimitiveTypeMode extends PrimitiveTypeMode
 private [squeryl] object InternalFieldMapper extends PrimitiveTypeMode
 
 trait PrimitiveTypeMode extends QueryDsl with FieldMapper {
-    
-  
-  // =========================== Non Numerical =========================== 
-  implicit val stringTEF = PrimitiveTypeSupport.stringTEF
-  implicit val optionStringTEF = PrimitiveTypeSupport.optionStringTEF
-  implicit val dateTEF = PrimitiveTypeSupport.dateTEF
-  implicit val optionDateTEF = PrimitiveTypeSupport.optionDateTEF
-  implicit val sqlDateTEF = PrimitiveTypeSupport.sqlDateTEF
-  implicit val optionSqlDateTEF = PrimitiveTypeSupport.optionSqlDateTEF
-  implicit val timestampTEF = PrimitiveTypeSupport.timestampTEF
-  implicit val optionTimestampTEF = PrimitiveTypeSupport.optionTimestampTEF
-  implicit val doubleArrayTEF = PrimitiveTypeSupport.doubleArrayTEF
-  implicit val intArrayTEF = PrimitiveTypeSupport.intArrayTEF
-  implicit val longArrayTEF = PrimitiveTypeSupport.longArrayTEF
-  implicit val stringArrayTEF = PrimitiveTypeSupport.stringArrayTEF
-  
-  // =========================== Numerical Integral =========================== 
-  implicit val byteTEF = PrimitiveTypeSupport.byteTEF
-  implicit val optionByteTEF = PrimitiveTypeSupport.optionByteTEF
-  implicit val intTEF = PrimitiveTypeSupport.intTEF
-  implicit val optionIntTEF = PrimitiveTypeSupport.optionIntTEF
-  implicit val longTEF = PrimitiveTypeSupport.longTEF
-  implicit val optionLongTEF = PrimitiveTypeSupport.optionLongTEF
-  
-  // =========================== Numerical Floating Point ===========================   
-  implicit val floatTEF = PrimitiveTypeSupport.floatTEF
-  implicit val optionFloatTEF = PrimitiveTypeSupport.optionFloatTEF
-  implicit val doubleTEF = PrimitiveTypeSupport.doubleTEF
-  implicit val optionDoubleTEF = PrimitiveTypeSupport.optionDoubleTEF  
-  implicit val bigDecimalTEF = PrimitiveTypeSupport.bigDecimalTEF
-  implicit val optionBigDecimalTEF = PrimitiveTypeSupport.optionBigDecimalTEF
-  
-  
-  implicit def stringToTE(s: String) = stringTEF.create(s)  
-  implicit def optionStringToTE(s: Option[String]) = optionStringTEF.create(s)
 
-  implicit def dateToTE(s: Date) = dateTEF.create(s)
-  implicit def optionDateToTE(s: Option[Date]) = optionDateTEF.create(s)
 
-  implicit def timestampToTE(s: Timestamp) = timestampTEF.create(s)
-  implicit def optionTimestampToTE(s: Option[Timestamp]) = optionTimestampTEF.create(s)
+  // =========================== Non Numerical ===========================
+  implicit val stringTEF: TypedExpressionFactory[String,TString] with PrimitiveJdbcMapper[String] = PrimitiveTypeSupport.stringTEF
+  implicit val optionStringTEF: TypedExpressionFactory[Option[String],TOptionString] with DeOptionizer[String, String, TString, Option[String], TOptionString] = PrimitiveTypeSupport.optionStringTEF
+  implicit val dateTEF: TypedExpressionFactory[Date,TDate] with PrimitiveJdbcMapper[Date] = PrimitiveTypeSupport.dateTEF
+  implicit val optionDateTEF: TypedExpressionFactory[Option[Date],TOptionDate] with DeOptionizer[Date, Date, TDate, Option[Date], TOptionDate] = PrimitiveTypeSupport.optionDateTEF
+  implicit val sqlDateTEF: TypedExpressionFactory[java.sql.Date,TDate] with PrimitiveJdbcMapper[java.sql.Date] = PrimitiveTypeSupport.sqlDateTEF
+  implicit val optionSqlDateTEF: TypedExpressionFactory[Option[java.sql.Date],TOptionDate] with DeOptionizer[java.sql.Date, java.sql.Date, TDate, Option[java.sql.Date], TOptionDate] = PrimitiveTypeSupport.optionSqlDateTEF
+  implicit val timestampTEF: TypedExpressionFactory[Timestamp,TTimestamp] with PrimitiveJdbcMapper[Timestamp] = PrimitiveTypeSupport.timestampTEF
+  implicit val optionTimestampTEF: TypedExpressionFactory[Option[Timestamp],TOptionTimestamp] with DeOptionizer[Timestamp, Timestamp, TTimestamp, Option[Timestamp], TOptionTimestamp] = PrimitiveTypeSupport.optionTimestampTEF
+  implicit val doubleArrayTEF: org.squeryl.internals.ArrayTEF[Double, TDoubleArray] = PrimitiveTypeSupport.doubleArrayTEF
+  implicit val intArrayTEF: org.squeryl.internals.ArrayTEF[Int, TIntArray] = PrimitiveTypeSupport.intArrayTEF
+  implicit val longArrayTEF: org.squeryl.internals.ArrayTEF[Long, TLongArray] = PrimitiveTypeSupport.longArrayTEF
+  implicit val stringArrayTEF: org.squeryl.internals.ArrayTEF[String, TStringArray] = PrimitiveTypeSupport.stringArrayTEF
 
-  implicit def booleanToTE(s: Boolean) = PrimitiveTypeSupport.booleanTEF.create(s)
-  implicit def optionBooleanToTE(s: Option[Boolean]) = PrimitiveTypeSupport.optionBooleanTEF.create(s)
+  // =========================== Numerical Integral ===========================
+  implicit val byteTEF: IntegralTypedExpressionFactory[Byte,TByte,Float,TFloat] with PrimitiveJdbcMapper[Byte] = PrimitiveTypeSupport.byteTEF
+  implicit val optionByteTEF: IntegralTypedExpressionFactory[Option[Byte],TOptionByte, Option[Float], TOptionFloat] with DeOptionizer[Byte, Byte, TByte, Option[Byte], TOptionByte] = PrimitiveTypeSupport.optionByteTEF
+  implicit val intTEF: IntegralTypedExpressionFactory[Int,TInt,Float,TFloat] with PrimitiveJdbcMapper[Int] = PrimitiveTypeSupport.intTEF
+  implicit val optionIntTEF: IntegralTypedExpressionFactory[Option[Int],TOptionInt,Option[Float],TOptionFloat] with DeOptionizer[Int,Int,TInt,Option[Int],TOptionInt] = PrimitiveTypeSupport.optionIntTEF
+  implicit val longTEF: IntegralTypedExpressionFactory[Long,TLong,Double,TDouble] with PrimitiveJdbcMapper[Long] = PrimitiveTypeSupport.longTEF
+  implicit val optionLongTEF: IntegralTypedExpressionFactory[Option[Long],TOptionLong,Option[Double],TOptionDouble] with DeOptionizer[Long,Long,TLong,Option[Long],TOptionLong] = PrimitiveTypeSupport.optionLongTEF
 
-  implicit def uuidToTE(s: UUID) = PrimitiveTypeSupport.uuidTEF.create(s)
-  implicit def optionUUIDToTE(s: Option[UUID]) = PrimitiveTypeSupport.optionUUIDTEF.create(s)
+  // =========================== Numerical Floating Point ===========================
+  implicit val floatTEF: FloatTypedExpressionFactory[Float,TFloat] with PrimitiveJdbcMapper[Float] = PrimitiveTypeSupport.floatTEF
+  implicit val optionFloatTEF: FloatTypedExpressionFactory[Option[Float],TOptionFloat] with DeOptionizer[Float,Float,TFloat,Option[Float],TOptionFloat] = PrimitiveTypeSupport.optionFloatTEF
+  implicit val doubleTEF: FloatTypedExpressionFactory[Double,TDouble] with PrimitiveJdbcMapper[Double] = PrimitiveTypeSupport.doubleTEF
+  implicit val optionDoubleTEF: FloatTypedExpressionFactory[Option[Double],TOptionDouble] with DeOptionizer[Double,Double,TDouble,Option[Double],TOptionDouble] = PrimitiveTypeSupport.optionDoubleTEF
+  implicit val bigDecimalTEF: FloatTypedExpressionFactory[BigDecimal,TBigDecimal] with PrimitiveJdbcMapper[BigDecimal] = PrimitiveTypeSupport.bigDecimalTEF
+  implicit val optionBigDecimalTEF: FloatTypedExpressionFactory[Option[BigDecimal],TOptionBigDecimal] with DeOptionizer[BigDecimal,BigDecimal,TBigDecimal,Option[BigDecimal],TOptionBigDecimal] = PrimitiveTypeSupport.optionBigDecimalTEF
 
-  implicit def binaryToTE(s: Array[Byte]) = PrimitiveTypeSupport.binaryTEF.create(s)
-  implicit def optionByteArrayToTE(s: Option[Array[Byte]]) = PrimitiveTypeSupport.optionByteArrayTEF.create(s)
+
+  implicit def stringToTE(s: String): TypedExpression[String,TString] = stringTEF.create(s)
+  implicit def optionStringToTE(s: Option[String]): TypedExpression[Option[String],TOptionString] = optionStringTEF.create(s)
+
+  implicit def dateToTE(s: Date): TypedExpression[Date,TDate] = dateTEF.create(s)
+  implicit def optionDateToTE(s: Option[Date]): TypedExpression[Option[Date],TOptionDate] = optionDateTEF.create(s)
+
+  implicit def timestampToTE(s: Timestamp): TypedExpression[Timestamp,TTimestamp] = timestampTEF.create(s)
+  implicit def optionTimestampToTE(s: Option[Timestamp]): TypedExpression[Option[Timestamp],TOptionTimestamp] = optionTimestampTEF.create(s)
+
+  implicit def booleanToTE(s: Boolean): TypedExpression[Boolean,TBoolean] = PrimitiveTypeSupport.booleanTEF.create(s)
+  implicit def optionBooleanToTE(s: Option[Boolean]): TypedExpression[Option[Boolean],TOptionBoolean] = PrimitiveTypeSupport.optionBooleanTEF.create(s)
+
+  implicit def uuidToTE(s: UUID): TypedExpression[UUID,TUUID] = PrimitiveTypeSupport.uuidTEF.create(s)
+  implicit def optionUUIDToTE(s: Option[UUID]): TypedExpression[Option[UUID],TOptionUUID] = PrimitiveTypeSupport.optionUUIDTEF.create(s)
+
+  implicit def binaryToTE(s: Array[Byte]): TypedExpression[Array[Byte],TByteArray] = PrimitiveTypeSupport.binaryTEF.create(s)
+  implicit def optionByteArrayToTE(s: Option[Array[Byte]]): TypedExpression[Option[Array[Byte]],TOptionByteArray] = PrimitiveTypeSupport.optionByteArrayTEF.create(s)
 
   implicit def enumValueToTE[A >: Enumeration#Value <: Enumeration#Value](e: A): TypedExpression[A, TEnumValue[A]] =
     PrimitiveTypeSupport.enumValueTEF[A](e).create(e)
-    
+
   implicit def optionEnumcValueToTE[A >: Enumeration#Value <: Enumeration#Value](e: Option[A]): TypedExpression[Option[A], TOptionEnumValue[A]] =
     PrimitiveTypeSupport.optionEnumValueTEF[A](e).create(e)
-  
-  implicit def byteToTE(f: Byte) = byteTEF.create(f)    
-  implicit def optionByteToTE(f: Option[Byte]) = optionByteTEF.create(f)
 
-  implicit def intToTE(f: Int) = intTEF.create(f)
-  implicit def optionIntToTE(f: Option[Int]) = optionIntTEF.create(f)
+  implicit def byteToTE(f: Byte): TypedExpression[Byte,TByte] = byteTEF.create(f)
+  implicit def optionByteToTE(f: Option[Byte]): TypedExpression[Option[Byte],TOptionByte] = optionByteTEF.create(f)
 
-  implicit def longToTE(f: Long) = longTEF.create(f)
-  implicit def optionLongToTE(f: Option[Long]) = optionLongTEF.create(f)
+  implicit def intToTE(f: Int): TypedExpression[Int,TInt] = intTEF.create(f)
+  implicit def optionIntToTE(f: Option[Int]): TypedExpression[Option[Int],TOptionInt] = optionIntTEF.create(f)
 
-  implicit def floatToTE(f: Float) = floatTEF.create(f)
-  implicit def optionFloatToTE(f: Option[Float]) = optionFloatTEF.create(f)
+  implicit def longToTE(f: Long): TypedExpression[Long,TLong] = longTEF.create(f)
+  implicit def optionLongToTE(f: Option[Long]): TypedExpression[Option[Long],TOptionLong] = optionLongTEF.create(f)
 
-  implicit def doubleToTE(f: Double) = doubleTEF.create(f)
-  implicit def optionDoubleToTE(f: Option[Double]) = optionDoubleTEF.create(f)
+  implicit def floatToTE(f: Float): TypedExpression[Float,TFloat] = floatTEF.create(f)
+  implicit def optionFloatToTE(f: Option[Float]): TypedExpression[Option[Float],TOptionFloat] = optionFloatTEF.create(f)
 
-  implicit def bigDecimalToTE(f: BigDecimal) = bigDecimalTEF.create(f)
-  implicit def optionBigDecimalToTE(f: Option[BigDecimal]) = optionBigDecimalTEF.create(f)
-  
-  implicit def doubleArrayToTE(f : Array[Double]) = doubleArrayTEF.create(f)
-  implicit def intArrayToTE(f : Array[Int]) = intArrayTEF.create(f)
-  implicit def longArrayToTE(f : Array[Long]) = longArrayTEF.create(f)
-  implicit def stringArrayToTE(f: Array[String]) = stringArrayTEF.create(f)
-  
+  implicit def doubleToTE(f: Double): TypedExpression[Double,TDouble] = doubleTEF.create(f)
+  implicit def optionDoubleToTE(f: Option[Double]): TypedExpression[Option[Double],TOptionDouble] = optionDoubleTEF.create(f)
 
-  implicit def logicalBooleanToTE(l: LogicalBoolean) =
+  implicit def bigDecimalToTE(f: BigDecimal): TypedExpression[BigDecimal,TBigDecimal] = bigDecimalTEF.create(f)
+  implicit def optionBigDecimalToTE(f: Option[BigDecimal]): TypedExpression[Option[BigDecimal],TOptionBigDecimal] = optionBigDecimalTEF.create(f)
+
+  implicit def doubleArrayToTE(f : Array[Double]): TypedExpression[Array[Double], TDoubleArray] = doubleArrayTEF.create(f)
+  implicit def intArrayToTE(f : Array[Int]): TypedExpression[Array[Int], TIntArray] = intArrayTEF.create(f)
+  implicit def longArrayToTE(f : Array[Long]): TypedExpression[Array[Long], TLongArray] = longArrayTEF.create(f)
+  implicit def stringArrayToTE(f: Array[String]): TypedExpression[Array[String], TStringArray] = stringArrayTEF.create(f)
+
+
+  implicit def logicalBooleanToTE(l: LogicalBoolean): TypedExpressionConversion[Boolean,TBoolean] =
     PrimitiveTypeSupport.booleanTEF.convert(l)
 
-  implicit def queryStringToTE(q: Query[String]) =
+  implicit def queryStringToTE(q: Query[String]): QueryValueExpressionNode[String, TString] =
     new QueryValueExpressionNode[String, TString](q.copy(false, Nil).ast, stringTEF.createOutMapper)
-  implicit def queryOptionStringToTE(q: Query[Option[String]]) =
+  implicit def queryOptionStringToTE(q: Query[Option[String]]): QueryValueExpressionNode[Option[String], TOptionString] =
     new QueryValueExpressionNode[Option[String], TOptionString](q.copy(false, Nil).ast, optionStringTEF.createOutMapper)
-  implicit def queryStringGroupedToTE(q: Query[Group[String]]) =
+  implicit def queryStringGroupedToTE(q: Query[Group[String]]): QueryValueExpressionNode[String, TString] =
     new QueryValueExpressionNode[String, TString](q.copy(false, Nil).ast, stringTEF.createOutMapper)
-  implicit def queryOptionStringGroupedToTE(q: Query[Group[Option[String]]]) =
+  implicit def queryOptionStringGroupedToTE(q: Query[Group[Option[String]]]): QueryValueExpressionNode[Option[String], TOptionString] =
     new QueryValueExpressionNode[Option[String], TOptionString](q.copy(false, Nil).ast, optionStringTEF.createOutMapper)
-  implicit def queryStringMeasuredToTE(q: Query[Measures[String]]) =
+  implicit def queryStringMeasuredToTE(q: Query[Measures[String]]): QueryValueExpressionNode[String, TString] =
     new QueryValueExpressionNode[String, TString](q.copy(false, Nil).ast, stringTEF.createOutMapper)
-  implicit def queryOptionStringMeasuredToTE(q: Query[Measures[Option[String]]]) =
+  implicit def queryOptionStringMeasuredToTE(q: Query[Measures[Option[String]]]): QueryValueExpressionNode[Option[String], TOptionString] =
     new QueryValueExpressionNode[Option[String], TOptionString](q.copy(false, Nil).ast, optionStringTEF.createOutMapper)
 
-  implicit def queryDateToTE(q: Query[Date]) =
+  implicit def queryDateToTE(q: Query[Date]): QueryValueExpressionNode[Date, TDate] =
     new QueryValueExpressionNode[Date, TDate](q.copy(false, Nil).ast, dateTEF.createOutMapper)
-  implicit def queryOptionDateToTE(q: Query[Option[Date]]) =
+  implicit def queryOptionDateToTE(q: Query[Option[Date]]): QueryValueExpressionNode[Option[Date], TOptionDate] =
     new QueryValueExpressionNode[Option[Date], TOptionDate](q.copy(false, Nil).ast, optionDateTEF.createOutMapper)
-  implicit def queryDateGroupedToTE(q: Query[Group[Date]]) =
+  implicit def queryDateGroupedToTE(q: Query[Group[Date]]): QueryValueExpressionNode[Date, TDate] =
     new QueryValueExpressionNode[Date, TDate](q.copy(false, Nil).ast, dateTEF.createOutMapper)
-  implicit def queryOptionDateGroupedToTE(q: Query[Group[Option[Date]]]) =
+  implicit def queryOptionDateGroupedToTE(q: Query[Group[Option[Date]]]): QueryValueExpressionNode[Option[Date], TOptionDate] =
     new QueryValueExpressionNode[Option[Date], TOptionDate](q.copy(false, Nil).ast, optionDateTEF.createOutMapper)
-  implicit def queryDateMeasuredToTE(q: Query[Measures[Date]]) =
+  implicit def queryDateMeasuredToTE(q: Query[Measures[Date]]): QueryValueExpressionNode[Date, TDate] =
     new QueryValueExpressionNode[Date, TDate](q.copy(false, Nil).ast, dateTEF.createOutMapper)
-  implicit def queryOptionDateMeasuredToTE(q: Query[Measures[Option[Date]]]) =
+  implicit def queryOptionDateMeasuredToTE(q: Query[Measures[Option[Date]]]): QueryValueExpressionNode[Option[Date], TOptionDate] =
     new QueryValueExpressionNode[Option[Date], TOptionDate](q.copy(false, Nil).ast, optionDateTEF.createOutMapper)
 
-  implicit def queryTimestampToTE(q: Query[Timestamp]) =
+  implicit def queryTimestampToTE(q: Query[Timestamp]): QueryValueExpressionNode[Timestamp, TTimestamp] =
     new QueryValueExpressionNode[Timestamp, TTimestamp](q.copy(false, Nil).ast, timestampTEF.createOutMapper)
-  implicit def queryOptionTimestampToTE(q: Query[Option[Timestamp]]) =
+  implicit def queryOptionTimestampToTE(q: Query[Option[Timestamp]]): QueryValueExpressionNode[Option[Timestamp], TOptionTimestamp] =
     new QueryValueExpressionNode[Option[Timestamp], TOptionTimestamp](q.copy(false, Nil).ast, optionTimestampTEF.createOutMapper)
-  implicit def queryTimestampGroupedToTE(q: Query[Group[Timestamp]]) =
+  implicit def queryTimestampGroupedToTE(q: Query[Group[Timestamp]]): QueryValueExpressionNode[Timestamp, TTimestamp] =
     new QueryValueExpressionNode[Timestamp, TTimestamp](q.copy(false, Nil).ast, timestampTEF.createOutMapper)
-  implicit def queryOptionTimestampGroupedToTE(q: Query[Group[Option[Timestamp]]]) =
+  implicit def queryOptionTimestampGroupedToTE(q: Query[Group[Option[Timestamp]]]): QueryValueExpressionNode[Option[Timestamp], TOptionTimestamp] =
     new QueryValueExpressionNode[Option[Timestamp], TOptionTimestamp](q.copy(false, Nil).ast, optionTimestampTEF.createOutMapper)
-  implicit def queryTimestampMeasuredToTE(q: Query[Measures[Timestamp]]) =
+  implicit def queryTimestampMeasuredToTE(q: Query[Measures[Timestamp]]): QueryValueExpressionNode[Timestamp, TTimestamp] =
     new QueryValueExpressionNode[Timestamp, TTimestamp](q.copy(false, Nil).ast, timestampTEF.createOutMapper)
-  implicit def queryOptionTimestampMeasuredToTE(q: Query[Measures[Option[Timestamp]]]) =
+  implicit def queryOptionTimestampMeasuredToTE(q: Query[Measures[Option[Timestamp]]]): QueryValueExpressionNode[Option[Timestamp], TOptionTimestamp] =
     new QueryValueExpressionNode[Option[Timestamp], TOptionTimestamp](q.copy(false, Nil).ast, optionTimestampTEF.createOutMapper)
 
-  implicit def queryBooleanToTE(q: Query[Boolean]) =
+  implicit def queryBooleanToTE(q: Query[Boolean]): QueryValueExpressionNode[Boolean, TBoolean] =
     new QueryValueExpressionNode[Boolean, TBoolean](q.copy(false, Nil).ast, PrimitiveTypeSupport.booleanTEF.createOutMapper)
-  implicit def queryOptionBooleanToTE(q: Query[Option[Boolean]]) =
+  implicit def queryOptionBooleanToTE(q: Query[Option[Boolean]]): QueryValueExpressionNode[Option[Boolean], TOptionBoolean] =
     new QueryValueExpressionNode[Option[Boolean], TOptionBoolean](q.copy(false, Nil).ast, PrimitiveTypeSupport.optionBooleanTEF.createOutMapper)
 
-  implicit def queryUUIDToTE(q: Query[UUID]) =
+  implicit def queryUUIDToTE(q: Query[UUID]): QueryValueExpressionNode[UUID, TUUID] =
     new QueryValueExpressionNode[UUID, TUUID](q.copy(false, Nil).ast, PrimitiveTypeSupport.uuidTEF.createOutMapper)
-  implicit def queryOptionUUIDToTE(q: Query[Option[UUID]]) =
+  implicit def queryOptionUUIDToTE(q: Query[Option[UUID]]): QueryValueExpressionNode[Option[UUID], TOptionUUID] =
     new QueryValueExpressionNode[Option[UUID], TOptionUUID](q.copy(false, Nil).ast, PrimitiveTypeSupport.optionUUIDTEF.createOutMapper)
 
-  implicit def queryByteArrayToTE(q: Query[Array[Byte]]) =
+  implicit def queryByteArrayToTE(q: Query[Array[Byte]]): QueryValueExpressionNode[Array[Byte], TByteArray] =
     new QueryValueExpressionNode[Array[Byte], TByteArray](q.copy(false, Nil).ast, PrimitiveTypeSupport.binaryTEF.createOutMapper)
-  implicit def queryOptionByteArrayToTE(q: Query[Option[Array[Byte]]]) =
+  implicit def queryOptionByteArrayToTE(q: Query[Option[Array[Byte]]]): QueryValueExpressionNode[Option[Array[Byte]], TOptionByteArray] =
     new QueryValueExpressionNode[Option[Array[Byte]], TOptionByteArray](q.copy(false, Nil).ast, PrimitiveTypeSupport.optionByteArrayTEF.createOutMapper)
 
-  implicit def queryByteToTE(q: Query[Byte]) =
+  implicit def queryByteToTE(q: Query[Byte]): QueryValueExpressionNode[Byte, TByte] =
     new QueryValueExpressionNode[Byte, TByte](q.copy(false, Nil).ast, byteTEF.createOutMapper)
-  implicit def queryOptionByteToTE(q: Query[Option[Byte]]) =
+  implicit def queryOptionByteToTE(q: Query[Option[Byte]]): QueryValueExpressionNode[Option[Byte], TOptionByte] =
     new QueryValueExpressionNode[Option[Byte], TOptionByte](q.copy(false, Nil).ast, optionByteTEF.createOutMapper)
-  implicit def queryByteGroupedToTE(q: Query[Group[Byte]]) =
+  implicit def queryByteGroupedToTE(q: Query[Group[Byte]]): QueryValueExpressionNode[Byte, TByte] =
     new QueryValueExpressionNode[Byte, TByte](q.copy(false, Nil).ast, byteTEF.createOutMapper)
-  implicit def queryOptionByteGroupedToTE(q: Query[Group[Option[Byte]]]) =
+  implicit def queryOptionByteGroupedToTE(q: Query[Group[Option[Byte]]]): QueryValueExpressionNode[Option[Byte], TOptionByte] =
     new QueryValueExpressionNode[Option[Byte], TOptionByte](q.copy(false, Nil).ast, optionByteTEF.createOutMapper)
-  implicit def queryByteMeasuredToTE(q: Query[Measures[Byte]]) =
+  implicit def queryByteMeasuredToTE(q: Query[Measures[Byte]]): QueryValueExpressionNode[Byte, TByte] =
     new QueryValueExpressionNode[Byte, TByte](q.copy(false, Nil).ast, byteTEF.createOutMapper)
-  implicit def queryOptionByteMeasuredToTE(q: Query[Measures[Option[Byte]]]) =
+  implicit def queryOptionByteMeasuredToTE(q: Query[Measures[Option[Byte]]]): QueryValueExpressionNode[Option[Byte], TOptionByte] =
     new QueryValueExpressionNode[Option[Byte], TOptionByte](q.copy(false, Nil).ast, optionByteTEF.createOutMapper)
 
-  implicit def queryIntToTE(q: Query[Int]) =
+  implicit def queryIntToTE(q: Query[Int]): QueryValueExpressionNode[Int, TInt] =
     new QueryValueExpressionNode[Int, TInt](q.copy(false, Nil).ast, intTEF.createOutMapper)
-  implicit def queryOptionIntToTE(q: Query[Option[Int]]) =
+  implicit def queryOptionIntToTE(q: Query[Option[Int]]): QueryValueExpressionNode[Option[Int], TOptionInt] =
     new QueryValueExpressionNode[Option[Int], TOptionInt](q.copy(false, Nil).ast, optionIntTEF.createOutMapper)
-  implicit def queryIntGroupedToTE(q: Query[Group[Int]]) =
+  implicit def queryIntGroupedToTE(q: Query[Group[Int]]): QueryValueExpressionNode[Int, TInt] =
     new QueryValueExpressionNode[Int, TInt](q.copy(false, Nil).ast, intTEF.createOutMapper)
-  implicit def queryOptionIntGroupedToTE(q: Query[Group[Option[Int]]]) =
+  implicit def queryOptionIntGroupedToTE(q: Query[Group[Option[Int]]]): QueryValueExpressionNode[Option[Int], TOptionInt] =
     new QueryValueExpressionNode[Option[Int], TOptionInt](q.copy(false, Nil).ast, optionIntTEF.createOutMapper)
-  implicit def queryIntMeasuredToTE(q: Query[Measures[Int]]) =
+  implicit def queryIntMeasuredToTE(q: Query[Measures[Int]]): QueryValueExpressionNode[Int, TInt] =
     new QueryValueExpressionNode[Int, TInt](q.copy(false, Nil).ast, intTEF.createOutMapper)
-  implicit def queryOptionIntMeasuredToTE(q: Query[Measures[Option[Int]]]) =
+  implicit def queryOptionIntMeasuredToTE(q: Query[Measures[Option[Int]]]): QueryValueExpressionNode[Option[Int], TOptionInt] =
     new QueryValueExpressionNode[Option[Int], TOptionInt](q.copy(false, Nil).ast, optionIntTEF.createOutMapper)
 
-  implicit def queryLongToTE(q: Query[Long]) =
+  implicit def queryLongToTE(q: Query[Long]): QueryValueExpressionNode[Long, TLong] =
     new QueryValueExpressionNode[Long, TLong](q.copy(false, Nil).ast, longTEF.createOutMapper)
-  implicit def queryOptionLongToTE(q: Query[Option[Long]]) =
+  implicit def queryOptionLongToTE(q: Query[Option[Long]]): QueryValueExpressionNode[Option[Long], TOptionLong] =
     new QueryValueExpressionNode[Option[Long], TOptionLong](q.copy(false, Nil).ast, optionLongTEF.createOutMapper)
-  implicit def queryLongGroupedToTE(q: Query[Group[Long]]) =
+  implicit def queryLongGroupedToTE(q: Query[Group[Long]]): QueryValueExpressionNode[Long, TLong] =
     new QueryValueExpressionNode[Long, TLong](q.copy(false, Nil).ast, longTEF.createOutMapper)
-  implicit def queryOptionLongGroupedToTE(q: Query[Group[Option[Long]]]) =
+  implicit def queryOptionLongGroupedToTE(q: Query[Group[Option[Long]]]): QueryValueExpressionNode[Option[Long], TOptionLong] =
     new QueryValueExpressionNode[Option[Long], TOptionLong](q.copy(false, Nil).ast, optionLongTEF.createOutMapper)
-  implicit def queryLongMeasuredToTE(q: Query[Measures[Long]]) =
+  implicit def queryLongMeasuredToTE(q: Query[Measures[Long]]): QueryValueExpressionNode[Long, TLong] =
     new QueryValueExpressionNode[Long, TLong](q.copy(false, Nil).ast, longTEF.createOutMapper)
-  implicit def queryOptionLongMeasuredToTE(q: Query[Measures[Option[Long]]]) =
+  implicit def queryOptionLongMeasuredToTE(q: Query[Measures[Option[Long]]]): QueryValueExpressionNode[Option[Long], TOptionLong] =
     new QueryValueExpressionNode[Option[Long], TOptionLong](q.copy(false, Nil).ast, optionLongTEF.createOutMapper)
 
-  implicit def queryFloatToTE(q: Query[Float]) =
+  implicit def queryFloatToTE(q: Query[Float]): QueryValueExpressionNode[Float, TFloat] =
     new QueryValueExpressionNode[Float, TFloat](q.copy(false, Nil).ast, floatTEF.createOutMapper)
-  implicit def queryOptionFloatToTE(q: Query[Option[Float]]) =
+  implicit def queryOptionFloatToTE(q: Query[Option[Float]]): QueryValueExpressionNode[Option[Float], TOptionFloat] =
     new QueryValueExpressionNode[Option[Float], TOptionFloat](q.copy(false, Nil).ast, optionFloatTEF.createOutMapper)
-  implicit def queryFloatGroupedToTE(q: Query[Group[Float]]) =
+  implicit def queryFloatGroupedToTE(q: Query[Group[Float]]): QueryValueExpressionNode[Float, TFloat] =
     new QueryValueExpressionNode[Float, TFloat](q.copy(false, Nil).ast, floatTEF.createOutMapper)
-  implicit def queryOptionFloatGroupedToTE(q: Query[Group[Option[Float]]]) =
+  implicit def queryOptionFloatGroupedToTE(q: Query[Group[Option[Float]]]): QueryValueExpressionNode[Option[Float], TOptionFloat] =
     new QueryValueExpressionNode[Option[Float], TOptionFloat](q.copy(false, Nil).ast, optionFloatTEF.createOutMapper)
-  implicit def queryFloatMeasuredToTE(q: Query[Measures[Float]]) =
+  implicit def queryFloatMeasuredToTE(q: Query[Measures[Float]]): QueryValueExpressionNode[Float, TFloat] =
     new QueryValueExpressionNode[Float, TFloat](q.copy(false, Nil).ast, floatTEF.createOutMapper)
-  implicit def queryOptionFloatMeasuredToTE(q: Query[Measures[Option[Float]]]) =
+  implicit def queryOptionFloatMeasuredToTE(q: Query[Measures[Option[Float]]]): QueryValueExpressionNode[Option[Float], TOptionFloat] =
     new QueryValueExpressionNode[Option[Float], TOptionFloat](q.copy(false, Nil).ast, optionFloatTEF.createOutMapper)
 
-  implicit def queryDoubleToTE(q: Query[Double]) =
+  implicit def queryDoubleToTE(q: Query[Double]): QueryValueExpressionNode[Double, TDouble] =
     new QueryValueExpressionNode[Double, TDouble](q.copy(false, Nil).ast, doubleTEF.createOutMapper)
-  implicit def queryOptionDoubleToTE(q: Query[Option[Double]]) =
+  implicit def queryOptionDoubleToTE(q: Query[Option[Double]]): QueryValueExpressionNode[Option[Double], TOptionDouble] =
     new QueryValueExpressionNode[Option[Double], TOptionDouble](q.copy(false, Nil).ast, optionDoubleTEF.createOutMapper)
-  implicit def queryDoubleGroupedToTE(q: Query[Group[Double]]) =
+  implicit def queryDoubleGroupedToTE(q: Query[Group[Double]]): QueryValueExpressionNode[Double, TDouble] =
     new QueryValueExpressionNode[Double, TDouble](q.copy(false, Nil).ast, doubleTEF.createOutMapper)
-  implicit def queryOptionDoubleGroupedToTE(q: Query[Group[Option[Double]]]) =
+  implicit def queryOptionDoubleGroupedToTE(q: Query[Group[Option[Double]]]): QueryValueExpressionNode[Option[Double], TOptionDouble] =
     new QueryValueExpressionNode[Option[Double], TOptionDouble](q.copy(false, Nil).ast, optionDoubleTEF.createOutMapper)
-  implicit def queryDoubleMeasuredToTE(q: Query[Measures[Double]]) =
+  implicit def queryDoubleMeasuredToTE(q: Query[Measures[Double]]): QueryValueExpressionNode[Double, TDouble] =
     new QueryValueExpressionNode[Double, TDouble](q.copy(false, Nil).ast, doubleTEF.createOutMapper)
-  implicit def queryOptionDoubleMeasuredToTE(q: Query[Measures[Option[Double]]]) =
+  implicit def queryOptionDoubleMeasuredToTE(q: Query[Measures[Option[Double]]]): QueryValueExpressionNode[Option[Double], TOptionDouble] =
     new QueryValueExpressionNode[Option[Double], TOptionDouble](q.copy(false, Nil).ast, optionDoubleTEF.createOutMapper)
 
-  implicit def queryBigDecimalToTE(q: Query[BigDecimal]) =
+  implicit def queryBigDecimalToTE(q: Query[BigDecimal]): QueryValueExpressionNode[BigDecimal, TBigDecimal] =
     new QueryValueExpressionNode[BigDecimal, TBigDecimal](q.copy(false, Nil).ast, bigDecimalTEF.createOutMapper)
-  implicit def queryOptionBigDecimalToTE(q: Query[Option[BigDecimal]]) =
+  implicit def queryOptionBigDecimalToTE(q: Query[Option[BigDecimal]]): QueryValueExpressionNode[Option[BigDecimal], TOptionBigDecimal] =
     new QueryValueExpressionNode[Option[BigDecimal], TOptionBigDecimal](q.copy(false, Nil).ast, optionBigDecimalTEF.createOutMapper)
-  implicit def queryBigDecimalGroupedToTE(q: Query[Group[BigDecimal]]) =
+  implicit def queryBigDecimalGroupedToTE(q: Query[Group[BigDecimal]]): QueryValueExpressionNode[BigDecimal, TBigDecimal] =
     new QueryValueExpressionNode[BigDecimal, TBigDecimal](q.copy(false, Nil).ast, bigDecimalTEF.createOutMapper)
-  implicit def queryOptionBigDecimalGroupedToTE(q: Query[Group[Option[BigDecimal]]]) =
+  implicit def queryOptionBigDecimalGroupedToTE(q: Query[Group[Option[BigDecimal]]]): QueryValueExpressionNode[Option[BigDecimal], TOptionBigDecimal] =
     new QueryValueExpressionNode[Option[BigDecimal], TOptionBigDecimal](q.copy(false, Nil).ast, optionBigDecimalTEF.createOutMapper)
-  implicit def queryBigDecimalMeasuredToTE(q: Query[Measures[BigDecimal]]) =
+  implicit def queryBigDecimalMeasuredToTE(q: Query[Measures[BigDecimal]]): QueryValueExpressionNode[BigDecimal, TBigDecimal] =
     new QueryValueExpressionNode[BigDecimal, TBigDecimal](q.copy(false, Nil).ast, bigDecimalTEF.createOutMapper)
-  implicit def queryOptionBigDecimalMeasuredToTE(q: Query[Measures[Option[BigDecimal]]]) =
+  implicit def queryOptionBigDecimalMeasuredToTE(q: Query[Measures[Option[BigDecimal]]]): QueryValueExpressionNode[Option[BigDecimal], TOptionBigDecimal] =
     new QueryValueExpressionNode[Option[BigDecimal], TOptionBigDecimal](q.copy(false, Nil).ast, optionBigDecimalTEF.createOutMapper)
 
 }

--- a/src/main/scala/org/squeryl/Schema.scala
+++ b/src/main/scala/org/squeryl/Schema.scala
@@ -29,7 +29,7 @@ import org.squeryl.internals.FieldMapper
 
 class Schema(implicit val fieldMapper: FieldMapper) {
 
-  protected implicit def thisSchema = this
+  protected implicit def thisSchema: Schema = this
 
   /**
    * Contains all Table[_]s in this shema, and also all ManyToManyRelation[_,_,_]s (since they are also Table[_]s
@@ -607,7 +607,7 @@ class Schema(implicit val fieldMapper: FieldMapper) {
    *
    * @return a instance of ActiveRecord associated to the given object.
    */
-  implicit def anyRef2ActiveTransaction[A](a: A)(implicit queryDsl: QueryDsl, m: ClassTag[A]) =
+  implicit def anyRef2ActiveTransaction[A](a: A)(implicit queryDsl: QueryDsl, m: ClassTag[A]): ActiveRecord[A] =
     new ActiveRecord(a, queryDsl, m)
 
   /**

--- a/src/main/scala/org/squeryl/customtypes/CustomTypesMode.scala
+++ b/src/main/scala/org/squeryl/customtypes/CustomTypesMode.scala
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2010 Maxime Lévesque
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,23 +28,23 @@ trait CustomType[T] extends Product1[T] {
 }
 
 trait CustomTypesMode extends QueryDsl with FieldMapper {
-  
+
   private[this] val ps = PrimitiveTypeSupport
-    
+
   val stringTEF = new NonPrimitiveJdbcMapper[String,StringField,TString](ps.stringTEF, this) {
     def convertFromJdbc(v: String) = new StringField(v)
     def convertToJdbc(v: StringField) = v.value
   }
-        
+
   val optionStringTEF = new TypedExpressionFactory[Option[StringField],TOptionString] with DeOptionizer[String, StringField, TString, Option[StringField], TOptionString]{
     val deOptionizer = stringTEF
   }
-    
+
   val dateTEF = new NonPrimitiveJdbcMapper[Date, DateField,TDate](ps.dateTEF, this) {
     def convertFromJdbc(v: Date) = new DateField(v)
     def convertToJdbc(v: DateField) = v.value
   }
-    
+
   val optionDateTEF = new TypedExpressionFactory[Option[DateField],TOptionDate] with DeOptionizer[Date, DateField, TDate, Option[DateField], TOptionDate] {
     val deOptionizer = dateTEF
   }
@@ -54,7 +54,7 @@ trait CustomTypesMode extends QueryDsl with FieldMapper {
     def convertToJdbc(v: TimestampField) = v.value
 
   }
-  
+
   val optionTimestampTEF = new TypedExpressionFactory[Option[TimestampField],TOptionTimestamp] with DeOptionizer[Timestamp, TimestampField, TTimestamp, Option[TimestampField], TOptionTimestamp] {
     val deOptionizer = timestampTEF
   }
@@ -63,27 +63,27 @@ trait CustomTypesMode extends QueryDsl with FieldMapper {
     def convertFromJdbc(v: Boolean) = new BooleanField(v)
     def convertToJdbc(v: BooleanField) = v.value
   }
-    
+
   val optionBooleanTEF = new TypedExpressionFactory[Option[BooleanField],TOptionBoolean] with DeOptionizer[Boolean, BooleanField, TBoolean, Option[BooleanField], TOptionBoolean] {
     val deOptionizer = booleanTEF
   }
-  
+
   val uuidTEF = new NonPrimitiveJdbcMapper[UUID,UuidField,TUUID](ps.uuidTEF, this) {
     def convertFromJdbc(v: UUID) = new UuidField(v)
     def convertToJdbc(v: UuidField) = v.value
   }
-        
+
   val optionUUIDTEF = new TypedExpressionFactory[Option[UuidField],TOptionUUID] with DeOptionizer[UUID, UuidField, TUUID, Option[UuidField], TOptionUUID] {
     val deOptionizer = uuidTEF
   }
-    
-    // =========================== Numerical Integral =========================== 
-  
+
+    // =========================== Numerical Integral ===========================
+
   val byteTEF = new NonPrimitiveJdbcMapper[Byte, ByteField,TByte](ps.byteTEF, this) {
     def convertFromJdbc(v: Byte) = new ByteField(v)
     def convertToJdbc(v: ByteField) = v.value
   }
-    
+
   val optionByteTEF = new IntegralTypedExpressionFactory[Option[ByteField],TOptionByte, Option[FloatField], TOptionFloat] with DeOptionizer[Byte, ByteField, TByte, Option[ByteField], TOptionByte] {
     val deOptionizer = byteTEF
     val floatifyer = optionFloatTEF
@@ -93,94 +93,94 @@ trait CustomTypesMode extends QueryDsl with FieldMapper {
     val floatifyer = floatTEF
     def convertFromJdbc(v: Int) = new IntField(v)
     def convertToJdbc(v: IntField) = v.value
-  }  
-    
+  }
+
   val optionIntTEF = new IntegralTypedExpressionFactory[Option[IntField],TOptionInt,Option[FloatField],TOptionFloat] with DeOptionizer[Int, IntField,TInt,Option[IntField],TOptionInt] {
     val deOptionizer = intTEF
     val floatifyer = optionFloatTEF
   }
-    
+
   val longTEF = new NonPrimitiveJdbcMapper[Long, LongField,TLong](ps.longTEF, this) with IntegralTypedExpressionFactory[LongField,TLong,DoubleField,TDouble] {
-    val floatifyer = doubleTEF      
+    val floatifyer = doubleTEF
     def convertFromJdbc(v: Long) = new LongField(v)
     def convertToJdbc(v: LongField) = v.value
   }
-  
+
   val optionLongTEF = new IntegralTypedExpressionFactory[Option[LongField],TOptionLong,Option[DoubleField],TOptionDouble] with DeOptionizer[Long,LongField,TLong,Option[LongField],TOptionLong] {
     val deOptionizer = longTEF
     val floatifyer = optionDoubleTEF
   }
-    
-  // =========================== Numerical Floating Point =========================== 
-    
+
+  // =========================== Numerical Floating Point ===========================
+
   val floatTEF = new NonPrimitiveJdbcMapper[Float, FloatField,TFloat](ps.floatTEF, this) with FloatTypedExpressionFactory[FloatField,TFloat] {
     def convertFromJdbc(v: Float) = new FloatField(v)
     def convertToJdbc(v: FloatField) = v.value
   }
-    
+
   val optionFloatTEF = new FloatTypedExpressionFactory[Option[FloatField],TOptionFloat] with DeOptionizer[Float,FloatField,TFloat,Option[FloatField],TOptionFloat] {
     val deOptionizer = floatTEF
   }
-    
-  val doubleTEF = new NonPrimitiveJdbcMapper[Double, DoubleField,TDouble](ps.doubleTEF, this) with FloatTypedExpressionFactory[DoubleField,TDouble] { 
+
+  val doubleTEF = new NonPrimitiveJdbcMapper[Double, DoubleField,TDouble](ps.doubleTEF, this) with FloatTypedExpressionFactory[DoubleField,TDouble] {
     def convertFromJdbc(v: Double) = new DoubleField(v)
     def convertToJdbc(v: DoubleField) = v.value
   }
-    
+
   val optionDoubleTEF = new FloatTypedExpressionFactory[Option[DoubleField],TOptionDouble] with DeOptionizer[Double,DoubleField,TDouble,Option[DoubleField],TOptionDouble] {
     val deOptionizer = doubleTEF
   }
-    
+
   val bigDecimalTEF = new NonPrimitiveJdbcMapper[BigDecimal, BigDecimalField,TBigDecimal](ps.bigDecimalTEF, this) with FloatTypedExpressionFactory[BigDecimalField,TBigDecimal] {
     def convertFromJdbc(v: BigDecimal) = new BigDecimalField(v)
     def convertToJdbc(v: BigDecimalField) = v.value
   }
-    
+
   val optionBigDecimalTEF = new FloatTypedExpressionFactory[Option[BigDecimalField],TOptionBigDecimal] with DeOptionizer[BigDecimal,BigDecimalField,TBigDecimal,Option[BigDecimalField],TOptionBigDecimal] {
     val deOptionizer = bigDecimalTEF
-  }      
-  
-  
-  implicit def stringToTE(s: String) = stringTEF.createFromNativeJdbcValue(s)  
-  implicit def optionStringToTE(s: Option[String]) = s.map(new StringField(_))
-  
-  
-  implicit def dateToTE(s: Date) = dateTEF.createFromNativeJdbcValue(s)
-  implicit def optionDateToTE(s: Option[Date]) = s.map(new DateField(_))
-  
-  implicit def timestampToTE(s: Timestamp) = timestampTEF.createFromNativeJdbcValue(s)    
-  implicit def optionTimestampToTE(s: Option[Timestamp]) = s.map(new TimestampField(_))
-  
-  implicit def booleanToTE(s: Boolean) = booleanTEF.createFromNativeJdbcValue(s)
-  implicit def optionBooleanToTE(s: Option[Boolean]) = s.map(new BooleanField(_))
-  
-  implicit def uuidToTE(s: UUID) = uuidTEF.createFromNativeJdbcValue(s)
-  implicit def optionUUIDToTE(s: Option[UUID]) = s.map(new UuidField(_))
-  
-  
-  implicit def byteToTE(f: Byte) = byteTEF.createFromNativeJdbcValue(f)    
-  implicit def optionByteToTE(f: Option[Byte]) = f.map(new ByteField(_))
+  }
 
-  implicit def intToTE(f: IntField) = intTEF.create(f)
-  implicit def optionIntToTE(f: Option[IntField]) = optionIntTEF.create(f)
-  
+
+  implicit def stringToTE(s: String): TypedExpression[StringField,TString] = stringTEF.createFromNativeJdbcValue(s)
+  implicit def optionStringToTE(s: Option[String]): Option[org.squeryl.customtypes.StringField] = s.map(new StringField(_))
+
+
+  implicit def dateToTE(s: Date): TypedExpression[DateField,TDate] = dateTEF.createFromNativeJdbcValue(s)
+  implicit def optionDateToTE(s: Option[Date]): Option[org.squeryl.customtypes.DateField] = s.map(new DateField(_))
+
+  implicit def timestampToTE(s: Timestamp): TypedExpression[TimestampField,TTimestamp] = timestampTEF.createFromNativeJdbcValue(s)
+  implicit def optionTimestampToTE(s: Option[Timestamp]): Option[org.squeryl.customtypes.TimestampField] = s.map(new TimestampField(_))
+
+  implicit def booleanToTE(s: Boolean): TypedExpression[BooleanField,TBoolean] = booleanTEF.createFromNativeJdbcValue(s)
+  implicit def optionBooleanToTE(s: Option[Boolean]): Option[org.squeryl.customtypes.BooleanField] = s.map(new BooleanField(_))
+
+  implicit def uuidToTE(s: UUID): TypedExpression[UuidField,TUUID] = uuidTEF.createFromNativeJdbcValue(s)
+  implicit def optionUUIDToTE(s: Option[UUID]): Option[org.squeryl.customtypes.UuidField] = s.map(new UuidField(_))
+
+
+  implicit def byteToTE(f: Byte): TypedExpression[ByteField,TByte] = byteTEF.createFromNativeJdbcValue(f)
+  implicit def optionByteToTE(f: Option[Byte]): Option[org.squeryl.customtypes.ByteField] = f.map(new ByteField(_))
+
+  implicit def intToTE(f: IntField): TypedExpression[IntField,TInt] = intTEF.create(f)
+  implicit def optionIntToTE(f: Option[IntField]): TypedExpression[Option[IntField],TOptionInt] = optionIntTEF.create(f)
+
   //implicit def _intToTE(f: Int) = intTEF.createFromNativeJdbcValue(f)
   //implicit def _optionIntToTE(f: Option[Int]) = f.map(new IntField(_))
-  
-  implicit def longToTE(f: Long) = longTEF.createFromNativeJdbcValue(f)
-  implicit def optionLongToTE(f: Option[Long]) = f.map(new LongField(_))
-  
-  implicit def floatToTE(f: Float) = floatTEF.createFromNativeJdbcValue(f)
-  implicit def optionFloatToTE(f: Option[Float]) = f.map(new FloatField(_))
-  
-  implicit def doubleToTE(f: Double) = doubleTEF.createFromNativeJdbcValue(f)
-  implicit def optionDoubleToTE(f: Option[Double]) = f.map(new DoubleField(_))
-  
-  implicit def bigDecimalToTE(f: BigDecimal) = bigDecimalTEF.createFromNativeJdbcValue(f)
-  implicit def optionBigDecimalToTE(f: Option[BigDecimal]) = f.map(new BigDecimalField(_))
+
+  implicit def longToTE(f: Long): TypedExpression[LongField,TLong] = longTEF.createFromNativeJdbcValue(f)
+  implicit def optionLongToTE(f: Option[Long]): Option[org.squeryl.customtypes.LongField] = f.map(new LongField(_))
+
+  implicit def floatToTE(f: Float): TypedExpression[FloatField,TFloat] = floatTEF.createFromNativeJdbcValue(f)
+  implicit def optionFloatToTE(f: Option[Float]): Option[org.squeryl.customtypes.FloatField] = f.map(new FloatField(_))
+
+  implicit def doubleToTE(f: Double): TypedExpression[DoubleField,TDouble] = doubleTEF.createFromNativeJdbcValue(f)
+  implicit def optionDoubleToTE(f: Option[Double]): Option[org.squeryl.customtypes.DoubleField] = f.map(new DoubleField(_))
+
+  implicit def bigDecimalToTE(f: BigDecimal): TypedExpression[BigDecimalField,TBigDecimal] = bigDecimalTEF.createFromNativeJdbcValue(f)
+  implicit def optionBigDecimalToTE(f: Option[BigDecimal]): Option[org.squeryl.customtypes.BigDecimalField] = f.map(new BigDecimalField(_))
 }
 
-object CustomTypesMode extends CustomTypesMode 
+object CustomTypesMode extends CustomTypesMode
 
 
 class ByteField(val value: Byte) extends CustomType[Byte]
@@ -206,4 +206,3 @@ class TimestampField(val value: Timestamp) extends CustomType[Timestamp]
 class BinaryField(val value: Array[Byte]) extends CustomType[Array[Byte]]
 
 class UuidField(val value: UUID) extends CustomType[UUID]
-

--- a/src/main/scala/org/squeryl/dsl/AbstractQuery.scala
+++ b/src/main/scala/org/squeryl/dsl/AbstractQuery.scala
@@ -127,7 +127,7 @@ abstract class AbstractQuery[R](
 
   def ast: QueryExpressionNode[R]
 
-  def copy(asRoot:Boolean, newUnions: List[(String, Query[R])]) = {
+  def copy(asRoot:Boolean, newUnions: List[(String, Query[R])]): AbstractQuery[R] = {
     val c = createCopy(asRoot, newUnions)
     c.selectDistinct = selectDistinct
     c.page = page

--- a/src/main/scala/org/squeryl/dsl/QueryDsl.scala
+++ b/src/main/scala/org/squeryl/dsl/QueryDsl.scala
@@ -139,7 +139,7 @@ trait QueryDsl
     
   implicit def typedExpression2OrderByArg[E](e: E)(implicit E: E => TypedExpression[_, _]): OrderByArg = new OrderByArg(e)
 
-  implicit def orderByArg2OrderByExpression(a: OrderByArg) = new OrderByExpression(a)
+  implicit def orderByArg2OrderByExpression(a: OrderByArg): OrderByExpression = new OrderByExpression(a)
 
   def sDevPopulation[T2 >: TOptionFloat, T1 <: T2, A1, A2]
          (b: TypedExpression[A1,T1])
@@ -194,15 +194,15 @@ trait QueryDsl
 
   def notExists[A1](query: Query[A1]) = new ExistsExpression(query.copy(false, Nil).ast, "not exists")
          
-  implicit val numericComparisonEvidence   = new CanCompare[TNumeric, TNumeric]         
-  implicit val dateComparisonEvidence      = new CanCompare[TOptionDate, TOptionDate]
-  implicit val timestampComparisonEvidence = new CanCompare[TOptionTimestamp, TOptionTimestamp]
-  implicit val stringComparisonEvidence    = new CanCompare[TOptionString, TOptionString]
-  implicit val booleanComparisonEvidence   = new CanCompare[TOptionBoolean, TOptionBoolean]
-  implicit val uuidComparisonEvidence      = new CanCompare[TOptionUUID, TOptionUUID]
-  implicit def enumComparisonEvidence[A]   = new CanCompare[TEnumValue[A],TEnumValue[A]]
-  
-  implicit def concatenationConversion[A1,A2,T1,T2](co: ConcatOp[A1,A2,T1,T2]): TypedExpression[String,TString] = 
+  implicit val numericComparisonEvidence: CanCompare[TNumeric, TNumeric]   = new CanCompare[TNumeric, TNumeric]
+  implicit val dateComparisonEvidence: CanCompare[TOptionDate, TOptionDate]      = new CanCompare[TOptionDate, TOptionDate]
+  implicit val timestampComparisonEvidence: CanCompare[TOptionTimestamp, TOptionTimestamp] = new CanCompare[TOptionTimestamp, TOptionTimestamp]
+  implicit val stringComparisonEvidence: CanCompare[TOptionString, TOptionString]    = new CanCompare[TOptionString, TOptionString]
+  implicit val booleanComparisonEvidence: CanCompare[TOptionBoolean, TOptionBoolean]   = new CanCompare[TOptionBoolean, TOptionBoolean]
+  implicit val uuidComparisonEvidence: CanCompare[TOptionUUID, TOptionUUID]      = new CanCompare[TOptionUUID, TOptionUUID]
+  implicit def enumComparisonEvidence[A]: CanCompare[TEnumValue[A],TEnumValue[A]]   = new CanCompare[TEnumValue[A],TEnumValue[A]]
+
+  implicit def concatenationConversion[A1,A2,T1,T2](co: ConcatOp[A1,A2,T1,T2]): TypedExpression[String,TString] =
     new ConcatOperationNode[String,TString](co.a1, co.a2, InternalFieldMapper.stringTEF.createOutMapper)
     
   implicit def concatenationConversionWithOption1[A1,A2,T1,T2](co: ConcatOp[Option[A1],A2,T1,T2]): TypedExpression[Option[String],TOptionString] = 
@@ -229,9 +229,9 @@ trait QueryDsl
 
   trait ScalarQuery[T] extends Query[T] with SingleColumnQuery[T] with SingleRowQuery[T]
 
-  implicit def scalarQuery2Scalar[T](sq: ScalarQuery[T]) = sq.head
+  implicit def scalarQuery2Scalar[T](sq: ScalarQuery[T]): T = sq.head
 
-  implicit def countQueryableToIntTypeQuery[R](q: Queryable[R]) = new CountSubQueryableQuery(q)
+  implicit def countQueryableToIntTypeQuery[R](q: Queryable[R]): CountSubQueryableQuery = new CountSubQueryableQuery(q)
 
   def count: CountFunction = count()
 
@@ -313,7 +313,7 @@ trait QueryDsl
 
   implicit def singleColComputeQuery2ScalarQuery[T](cq: Query[Measures[T]]): ScalarQuery[T] = new ScalarMeasureQuery[T](cq)
   
-  implicit def singleColComputeQuery2Scalar[T](cq: Query[Measures[T]]) = new ScalarMeasureQuery[T](cq).head
+  implicit def singleColComputeQuery2Scalar[T](cq: Query[Measures[T]]): T = new ScalarMeasureQuery[T](cq).head
 
   class ScalarMeasureQuery[T](q: Query[Measures[T]]) extends Query[T] with ScalarQuery[T] {
 
@@ -359,7 +359,7 @@ trait QueryDsl
   /**
    * Used for supporting 'inhibitWhen' dynamic queries
    */
-  implicit def queryable2OptionalQueryable[A](q: Queryable[A]) = new OptionalQueryable[A](q)
+  implicit def queryable2OptionalQueryable[A](q: Queryable[A]): OptionalQueryable[A] = new OptionalQueryable[A](q)
 
   //implicit def view2QueryAll[A](v: View[A]) = from(v)(a=> select(a))
 
@@ -804,14 +804,14 @@ trait QueryDsl
   implicit def t2te[A1,A2](t: (A1,A2))(
       implicit
         ev1: A1 => TypedExpression[A1, _],
-        ev2: A2 => TypedExpression[A2, _]) =
+        ev2: A2 => TypedExpression[A2, _]): CompositeKey2[A1,A2] =
     new CompositeKey2[A1,A2](t._1, t._2)
 
   implicit def t3te[A1,A2,A3](t: (A1,A2,A3))(
       implicit
         ev1: A1 => TypedExpression[A1, _],
         ev2: A2 => TypedExpression[A2, _],
-        ev3: A3 => TypedExpression[A3, _]) =
+        ev3: A3 => TypedExpression[A3, _]): CompositeKey3[A1,A2,A3] =
     new CompositeKey3[A1,A2,A3](t._1, t._2, t._3)
 
   implicit def t4te[A1,A2,A3,A4](t: (A1,A2,A3,A4))(
@@ -819,7 +819,7 @@ trait QueryDsl
         ev1: A1 => TypedExpression[A1, _],
         ev2: A2 => TypedExpression[A2, _],
         ev3: A3 => TypedExpression[A3, _],
-        ev4: A4 => TypedExpression[A4, _]) =
+        ev4: A4 => TypedExpression[A4, _]): CompositeKey4[A1,A2,A3,A4] =
     new CompositeKey4[A1,A2,A3,A4](t._1, t._2, t._3, t._4)
 
   implicit def t5te[A1,A2,A3,A4,A5](t: (A1,A2,A3,A4,A5))(
@@ -828,7 +828,7 @@ trait QueryDsl
         ev2: A2 => TypedExpression[A2, _],
         ev3: A3 => TypedExpression[A3, _],
         ev4: A4 => TypedExpression[A4, _],
-        ev5: A5 => TypedExpression[A5, _]) =
+        ev5: A5 => TypedExpression[A5, _]): CompositeKey5[A1,A2,A3,A4,A5] =
     new CompositeKey5[A1,A2,A3,A4,A5](t._1, t._2, t._3, t._4, t._5)
 
   implicit def t6te[A1,A2,A3,A4,A5,A6](t: (A1,A2,A3,A4,A5,A6))(
@@ -838,7 +838,7 @@ trait QueryDsl
         ev3: A3 => TypedExpression[A3, _],
         ev4: A4 => TypedExpression[A4, _],
         ev5: A5 => TypedExpression[A5, _],
-        ev6: A6 => TypedExpression[A6, _]) =
+        ev6: A6 => TypedExpression[A6, _]): CompositeKey6[A1,A2,A3,A4,A5,A6] =
     new CompositeKey6[A1,A2,A3,A4,A5,A6](t._1, t._2, t._3, t._4, t._5, t._6)
 
   implicit def t7te[A1,A2,A3,A4,A5,A6,A7](t: (A1,A2,A3,A4,A5,A6,A7))(
@@ -849,7 +849,7 @@ trait QueryDsl
         ev4: A4 => TypedExpression[A4, _],
         ev5: A5 => TypedExpression[A5, _],
         ev6: A6 => TypedExpression[A6, _],
-        ev7: A7 => TypedExpression[A7, _]) =
+        ev7: A7 => TypedExpression[A7, _]): CompositeKey7[A1,A2,A3,A4,A5,A6,A7] =
     new CompositeKey7[A1,A2,A3,A4,A5,A6,A7](t._1, t._2, t._3, t._4, t._5, t._6, t._7)
 
   implicit def t8te[A1,A2,A3,A4,A5,A6,A7,A8](t: (A1,A2,A3,A4,A5,A6,A7,A8))(
@@ -861,7 +861,7 @@ trait QueryDsl
         ev5: A5 => TypedExpression[A5, _],
         ev6: A6 => TypedExpression[A6, _],
         ev7: A7 => TypedExpression[A7, _],
-        ev8: A8 => TypedExpression[A8, _]) =
+        ev8: A8 => TypedExpression[A8, _]): CompositeKey8[A1,A2,A3,A4,A5,A6,A7,A8] =
     new CompositeKey8[A1,A2,A3,A4,A5,A6,A7,A8](t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8)
 
   implicit def t9te[A1,A2,A3,A4,A5,A6,A7,A8,A9](t: (A1,A2,A3,A4,A5,A6,A7,A8,A9))(
@@ -874,7 +874,7 @@ trait QueryDsl
         ev6: A6 => TypedExpression[A6, _],
         ev7: A7 => TypedExpression[A7, _],
         ev8: A8 => TypedExpression[A8, _],
-        ev9: A9 => TypedExpression[A9, _]) =
+        ev9: A9 => TypedExpression[A9, _]): CompositeKey9[A1,A2,A3,A4,A5,A6,A7,A8,A9] =
     new CompositeKey9[A1,A2,A3,A4,A5,A6,A7,A8,A9](t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
 
   implicit def compositeKey2CanLookup[T <: CompositeKey](t: T): CanLookup = CompositeKeyLookup

--- a/src/main/scala/org/squeryl/dsl/ast/ViewExpressionNode.scala
+++ b/src/main/scala/org/squeryl/dsl/ast/ViewExpressionNode.scala
@@ -28,14 +28,14 @@ class ViewExpressionNode[U](val view: View[U])
 
   def getOrCreateAllSelectElements(forScope: QueryExpressionElements): Iterable[SelectElement] = {
 
-    val export = ! forScope.isChild(this)
+    val exportElement = ! forScope.isChild(this)
 
     view.posoMetaData.fieldsMetaData.map(fmd =>
-      getOrCreateSelectElement(fmd, export)
+      getOrCreateSelectElement(fmd, exportElement)
     )
   }
 
-  private def getOrCreateSelectElement(fmd: FieldMetaData, export: Boolean): SelectElement = {
+  private def getOrCreateSelectElement(fmd: FieldMetaData, exportElement: Boolean): SelectElement = {
 
     val e = _selectElements.get(fmd)
     val n =
@@ -47,7 +47,7 @@ class ViewExpressionNode[U](val view: View[U])
         r
       }
 
-    if(export)
+    if(exportElement)
       new ExportedSelectElement(n)
     else
       n

--- a/src/main/scala/org/squeryl/dsl/boilerplate/JoinSignatures.scala
+++ b/src/main/scala/org/squeryl/dsl/boilerplate/JoinSignatures.scala
@@ -28,9 +28,9 @@ trait JoinSignatures {
     def fullOuter = new OuterJoinedQueryable[A](q, "full")
   }
 
-  implicit def queryable2JoinPrecursor[A](q: Queryable[A]) = new JoinPrecursor[A](q)
+  implicit def queryable2JoinPrecursor[A](q: Queryable[A]): JoinPrecursor[A] = new JoinPrecursor[A](q)
 
-  implicit def queryable2RightInnerJoinedQueryable[A](q: Queryable[A]) = new InnerJoinedQueryable[A](q, "")
+  implicit def queryable2RightInnerJoinedQueryable[A](q: Queryable[A]): InnerJoinedQueryable[A] = new InnerJoinedQueryable[A](q, "")
 
   def join[A,B1,C](q: Queryable[A], q1: JoinedQueryable[B1])(f: Function2[A,B1,JoinQueryYield1[C]]): Query[C] =
     from(q,q1)(

--- a/src/main/scala/org/squeryl/internals/ArrayTEF.scala
+++ b/src/main/scala/org/squeryl/internals/ArrayTEF.scala
@@ -18,8 +18,7 @@ abstract class ArrayTEF[P, TE] extends TypedExpressionFactory[Array[P], TE] with
     val con = s.connection
     var rv: java.sql.Array = null
     try {
-      //asInstanceOf required for 2.9.0-1 to compile
-      val typ = s.databaseAdapter.arrayCreationType(sample(0).asInstanceOf[{ def getClass : Class[_] }].getClass)
+      val typ = s.databaseAdapter.arrayCreationType(sample(0).getClass)
       rv = con.createArrayOf(typ, content)
     } catch {
       case e: Exception => s.log("Cannot create JDBC array: " + e.getMessage)

--- a/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
+++ b/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
@@ -855,7 +855,7 @@ trait DatabaseAdapter {
 
   def databaseTypeFor(fieldMapper: FieldMapper, c: Class[_]): String = {
     val ar = fieldMapper.sampleValueFor(c)
-    val decl = 
+    val decl: String = 
       if(ar.isInstanceOf[Enumeration#Value])                 
         intTypeDeclaration
       else if(classOf[String].isAssignableFrom(c))

--- a/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
+++ b/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
@@ -40,7 +40,7 @@ trait DatabaseAdapter {
     def zipi = this
   }
 
-  implicit def zipIterable[T](i: Iterable[T]) = new ZipIterable(i)
+  implicit def zipIterable[T](i: Iterable[T]): ZipIterable[T] = new ZipIterable(i)
 
   def writeQuery(qen: QueryExpressionElements, sw: StatementWriter):Unit =
     writeQuery(qen, sw, false, None)
@@ -337,17 +337,9 @@ trait DatabaseAdapter {
   
   def setParamInto(s: PreparedStatement, p: StatementParam, i: Int) =
     p match {
-    	case ConstantStatementParam(constantTypedExpression) =>
-    	  
-    	  //val t = jdbcTypeConstantFor(constantTypedExpression.jdbcClass)    	  
-    	  s.setObject(i, convertToJdbcValue(constantTypedExpression.nativeJdbcValue))
-    	case FieldStatementParam(o, fieldMetaData) =>
-    	  
-    	  //val t = jdbcTypeConstantFor(fieldMetaData.nativeJdbcType)    	  
-    	  //s.setObject(i, convertToJdbcValue(fieldMetaData.get(o)))
-        s.setObject(i, convertToJdbcValue(fieldMetaData.getNativeJdbcValue(o)))    	  
-    	case ConstantExpressionNodeListParam(v, constantExpressionNodeList) =>
-    	  s.setObject(i, convertToJdbcValue(v))
+      case ConstantStatementParam(constantTypedExpression) => s.setObject(i, convertToJdbcValue(constantTypedExpression.nativeJdbcValue))
+      case FieldStatementParam(o, fieldMetaData) => s.setObject(i, convertToJdbcValue(fieldMetaData.getNativeJdbcValue(o)))
+      case ConstantExpressionNodeListParam(v, constantExpressionNodeList) => s.setObject(i, convertToJdbcValue(v))
     }
 
   private def _exec[A](s: AbstractSession, sw: StatementWriter, block: Iterable[StatementParam]=>A, args: Iterable[StatementParam]): A =
@@ -402,7 +394,7 @@ trait DatabaseAdapter {
     }
   }
   
-  implicit def string2StatementWriter(s: String) = {
+  implicit def string2StatementWriter(s: String): StatementWriter = {
     val sw = new StatementWriter(this)
     sw.write(s)
     sw
@@ -939,22 +931,22 @@ trait DatabaseAdapter {
   
   def jdbcTypeConstantFor(c: Class[_]) =
     c.getCanonicalName match {
-		case "java.lang.String" => Types.VARCHAR
-		case "java.math.BigDecimal" => Types.DECIMAL
-		case "java.lang.Boolean" => Types.BIT
-		case "java.lang.Byte" => Types.TINYINT
-		case "java.lang.Integer" => Types.INTEGER
-		case "java.lang.Long" => Types.BIGINT
-		case "java.lang.Float" => Types.FLOAT
-		case "java.lang.Double" => Types.DOUBLE
-		case "java.lang.Byte[]" => Types.BINARY
-		case "byte[]" => Types.BINARY
-		case "java.sql.Date" => Types.DATE
-		case "java.util.Date" => Types.DATE
-		case "java.sql.Timestamp" => Types.TIMESTAMP
-		case "java.util.UUID" => Types.VARCHAR
-		case "scala.math.BigDecimal" => Types.VARCHAR
-		case s:Any =>
-		  throw new RuntimeException("Don't know jdbc type for " + s)
+      case "java.lang.String" => Types.VARCHAR
+      case "java.math.BigDecimal" => Types.DECIMAL
+      case "java.lang.Boolean" => Types.BIT
+      case "java.lang.Byte" => Types.TINYINT
+      case "java.lang.Integer" => Types.INTEGER
+      case "java.lang.Long" => Types.BIGINT
+      case "java.lang.Float" => Types.FLOAT
+      case "java.lang.Double" => Types.DOUBLE
+      case "java.lang.Byte[]" => Types.BINARY
+      case "byte[]" => Types.BINARY
+      case "java.sql.Date" => Types.DATE
+      case "java.util.Date" => Types.DATE
+      case "java.sql.Timestamp" => Types.TIMESTAMP
+      case "java.util.UUID" => Types.VARCHAR
+      case "scala.math.BigDecimal" => Types.VARCHAR
+      case s:Any =>
+        throw new RuntimeException("Don't know jdbc type for " + s)
   }  
 }

--- a/src/main/scala/org/squeryl/internals/FieldMapper.scala
+++ b/src/main/scala/org/squeryl/internals/FieldMapper.scala
@@ -29,7 +29,7 @@ trait FieldMapper {
     
   private[this] val registry = new HashMap[Class[_],FieldAttributesBasedOnType[_]]
 
-  implicit def thisFieldMapper = this
+  implicit def thisFieldMapper: FieldMapper = this
 
   /**
    * Extending classes will expose members of PrimitiveTypeSupport as implicit, to enable

--- a/src/main/scala/org/squeryl/internals/FieldMapper.scala
+++ b/src/main/scala/org/squeryl/internals/FieldMapper.scala
@@ -283,7 +283,7 @@ trait FieldMapper {
      * in FieldMetaData.canonicalEnumerationValueFor(i: Int) 
      */
     val z = new FieldAttributesBasedOnType[Any](
-        new {
+        new MapperForReflection {
           def map(rs:ResultSet,i:Int) = rs.getInt(i)
           def convertToJdbc(v: AnyRef) = v
         }, 
@@ -293,14 +293,14 @@ trait FieldMapper {
         
     registry.put(z.clasz, z)
     registry.put(z.clasz.getSuperclass, z)
-  }  
-    
-  protected type MapperForReflection = {
+  }
+
+  protected trait MapperForReflection {
     def map(rs:ResultSet,i:Int): Any
     def convertToJdbc(v: AnyRef): AnyRef
   }
-   
-  protected def makeMapper(fa0: JdbcMapper[_,_]) = new {
+
+  protected def makeMapper(fa0: JdbcMapper[_,_]) = new MapperForReflection {
     val fa = fa0.asInstanceOf[JdbcMapper[AnyRef,AnyRef]]
     
     def map(rs:ResultSet,i:Int) = fa.map(rs, i)

--- a/src/main/scala/org/squeryl/internals/FieldMetaData.scala
+++ b/src/main/scala/org/squeryl/internals/FieldMetaData.scala
@@ -88,7 +88,7 @@ class FieldMetaData(
 
   def sequenceName: String = {
 
-    val ai = _columnAttributes.collectFirst{case a: AutoIncremented => a}.
+    val ai: AutoIncremented = _columnAttributes.collectFirst{case a: AutoIncremented => a}.
       getOrElse(org.squeryl.internals.Utils.throwError(s"${this} is not declared as autoIncremented, hence it has no sequenceName"))
 
     if(ai.nameOfSequence != None) {
@@ -399,22 +399,21 @@ object FieldMetaData {
        * it is not None, we can use it to deduce the Option type.   
        */
       var v: AnyRef =
-         if(sampleInstance4OptionTypeDeduction != null) {
-           field flatMap { f =>
-             f.get(sampleInstance4OptionTypeDeduction) match {
-               case a: AnyRef => Some(a)
-               case _ => None
-             }
-           } orElse {
-	             getter flatMap { _.invoke(sampleInstance4OptionTypeDeduction, _EMPTY_ARRAY : _*) match {
-	               case a: AnyRef => Some(a)
-	               case _ => None
-	             }
-             }
-           } getOrElse
-            createDefaultValue(fieldMapper, member, clsOfField, Some(typeOfField), colAnnotation)
-         }
-         else null
+        if(sampleInstance4OptionTypeDeduction != null) {
+          field.flatMap { f: Field =>
+            f.get(sampleInstance4OptionTypeDeduction) match {
+              case a: AnyRef => Some(a)
+              case _ => None
+            }
+          }.orElse {
+            getter flatMap {
+              _.invoke(sampleInstance4OptionTypeDeduction, _EMPTY_ARRAY : _*) match {
+                case a: AnyRef => Some(a)
+                case _ => None
+              }
+            }
+          }.getOrElse(createDefaultValue(fieldMapper, member, clsOfField, Some(typeOfField), colAnnotation))
+        } else null
 
       if(v != null && v == None) // can't deduce the type from None keep trying
         v = null
@@ -581,41 +580,41 @@ object FieldMetaData {
   def createDefaultValue(fieldMapper: FieldMapper, member: Member, p: Class[_], t: Option[Type], optionFieldsInfo: Option[Column]): Object = {
     if (p.isAssignableFrom(classOf[Option[Any]])) {
       /*
-       * First we'll look at the annotation if it exists as it's the lowest cost.
-       */
-       optionFieldsInfo.flatMap(ann => 
-         if(ann.optionType != classOf[Object])
-           Some(createDefaultValue(fieldMapper, member, ann.optionType, None, None))
-          else None).orElse{
-	      /*
-	       * Next we'll try the Java generic type.  This will fail if the generic parameter is a primitive as
-	       * we'll see Object instead of scala.X
-	       */
-	      t match {
-	        case Some(pt: ParameterizedType) => {
-	          pt.getActualTypeArguments.toList match {
-	            case oType :: Nil => {
-	              if(classOf[Class[_]].isInstance(oType)) {
-	                /*
-	                 * Primitive types are seen by Java reflection as classOf[Object], 
-	                 * if that's what we find then we need to get the real value from @ScalaSignature
-	                 */
-	                val trueTypeOption = 
-	                  if (classOf[Object] == oType) optionTypeFromScalaSig(member)
-	                  else Some(oType.asInstanceOf[Class[_]])
-	                trueTypeOption flatMap { trueType =>
-	                  val deduced = createDefaultValue(fieldMapper, member, trueType, None, optionFieldsInfo)
-	                  Option(deduced) // Couldn't create default for type param if null
-	                }
-	              } else{
-	            	  None //Type parameter is not a Class
-	              }
-	            }
-	            case _ => None //Not a single type parameter
-	          }
-	        }
-	        case _ => None //Not a parameterized type
-	      } 
+       +      * First we'll look at the annotation if it exists as it's the lowest cost.
+      */
+      optionFieldsInfo.flatMap(ann =>
+        if(ann.optionType != classOf[Object]) Some(createDefaultValue(fieldMapper, member, ann.optionType, None, None))
+        else None
+      ).orElse {
+        /*
+        * Next we'll try the Java generic type.  This will fail if the generic parameter is a primitive as
+        * we'll see Object instead of scala.X
+        */
+        t match {
+            case Some(pt: ParameterizedType) => {
+              pt.getActualTypeArguments.toList match {
+                case oType :: Nil => {
+                  if(classOf[Class[_]].isInstance(oType)) {
+                    /*
+                    * Primitive types are seen by Java reflection as classOf[Object],
+                    * if that's what we find then we need to get the real value from @ScalaSignature
+                    */
+                    val trueTypeOption =
+                    if (classOf[Object] == oType) optionTypeFromScalaSig(member)
+                    else Some(oType.asInstanceOf[Class[_]])
+                    trueTypeOption flatMap { trueType =>
+                      val deduced = createDefaultValue(fieldMapper, member, trueType, None, optionFieldsInfo)
+                      Option(deduced) // Couldn't create default for type param if null
+                    }
+                  } else{
+                  None //Type parameter is not a Class
+                  }
+                }
+                case _ => None //Not a single type parameter
+              }
+            }
+          case _ => None //Not a parameterized type
+        }
       }
     } 
     else {      

--- a/src/main/scala/org/squeryl/internals/FieldReferenceLinker.scala
+++ b/src/main/scala/org/squeryl/internals/FieldReferenceLinker.scala
@@ -240,41 +240,40 @@ object FieldReferenceLinker {
    */
   private object _declaredFieldCache {
   
-	  @volatile var _cache: Map[Class[_], Array[Field]] =
-			  Map[Class[_], Array[Field]]()
+    @volatile var _cache: Map[Class[_], Array[Field]] =
+      Map[Class[_], Array[Field]]()
 
-	  def apply(cls: Class[_]) =
-	    _cache.get(cls) getOrElse {
-	      val declaredFields = cls.getDeclaredFields()
-	      _cache += ((cls, declaredFields))
-	      declaredFields
-	    }
-	  
+    def apply(cls: Class[_]) =
+      _cache.get(cls) getOrElse {
+        val declaredFields = cls.getDeclaredFields()
+          _cache += ((cls, declaredFields))
+        declaredFields
+      }
   }
 
   private def _populateSelectColsRecurse(visited: java.util.IdentityHashMap[AnyRef, AnyRef] , yi: YieldInspection,q: QueryExpressionElements, o: AnyRef): Unit =
-	  if(o != null && o != None) {
-		  if(!visited.containsKey(o)) {
-			  val clazz = o.getClass
-			  val clazzName = clazz.getName
-			  //println("Looking at " + clazzName)
-			  if(!clazzName.startsWith("java.") && 
-					  !clazzName.startsWith("net.sf.cglib.") && 
-					  !clazzName.startsWith("scala.Enumeration")) {
-				  visited.put(o,o)
-				  _populateSelectCols(yi, q, o)
-				  for(f <- _declaredFieldCache(clazz)) {
-					  f.setAccessible(true);
-					  val ob = f.get(o)
-					  if(!f.getName.startsWith("CGLIB$") && 
-					        !f.getType.getName.startsWith("scala.Function") && 
-					        !FieldMetaData.factory.hideFromYieldInspection(o, f)) {
-						  _populateSelectColsRecurse(visited, yi, q, ob)
-					  }
-				  }
-			  }
-		  }
-	  }
+    if(o != null && o != None) {
+      if(!visited.containsKey(o)) {
+        val clazz = o.getClass
+        val clazzName = clazz.getName
+        //println("Looking at " + clazzName)
+        if(!clazzName.startsWith("java.") &&
+        !clazzName.startsWith("net.sf.cglib.") &&
+        !clazzName.startsWith("scala.Enumeration")) {
+          visited.put(o,o)
+          _populateSelectCols(yi, q, o)
+          for(f <- _declaredFieldCache(clazz)) {
+            f.setAccessible(true);
+            val ob = f.get(o)
+            if(!f.getName.startsWith("CGLIB$") &&
+            !f.getType.getName.startsWith("scala.Function") &&
+            !FieldMetaData.factory.hideFromYieldInspection(o, f)) {
+              _populateSelectColsRecurse(visited, yi, q, ob)
+            }
+          }
+        }
+      }
+    }
   
   
   private def _populateSelectCols(yi: YieldInspection,q: QueryExpressionElements, sample: AnyRef): Unit = {

--- a/src/main/scala/org/squeryl/internals/ResultSetMapper.scala
+++ b/src/main/scala/org/squeryl/internals/ResultSetMapper.scala
@@ -160,7 +160,7 @@ class ColumnToTupleMapper(val outMappers: Array[OutMapper[_]]) {
       case 21 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs), m(15).map(rs), m(16).map(rs), m(17).map(rs), m(18).map(rs), m(19).map(rs), m(20).map(rs))
       case 22 => (m(0).map(rs), m(1).map(rs), m(2).map(rs), m(3).map(rs), m(4).map(rs), m(5).map(rs), m(6).map(rs), m(7).map(rs), m(8).map(rs), m(9).map(rs), m(10).map(rs), m(11).map(rs), m(12).map(rs), m(13).map(rs), m(14).map(rs), m(15).map(rs), m(16).map(rs), m(17).map(rs), m(18).map(rs), m(19).map(rs), m(20).map(rs), m(21).map(rs))
 
-      case z:Any => org.squeryl.internals.Utils.throwError("tuples of size "+size+" and greater are not supported")
+      case _ => org.squeryl.internals.Utils.throwError("tuples of size "+size+" and greater are not supported")
     }
     
     res.asInstanceOf[T]

--- a/src/main/scala/org/squeryl/logging/StatsSchema.scala
+++ b/src/main/scala/org/squeryl/logging/StatsSchema.scala
@@ -46,7 +46,7 @@ class StatementInvocation(
     new CompositeKey2(statementHash, statementHashCollisionNumber)
 
   def executeTime =
-    end minus start
+    end - start
 }
 
 object StatementHasher {


### PR DESCRIPTION
This PR prepares the codebase further for scala 3 by fixing a few minor things that the scala 3 compiler will complain about (in light of the work done in #296). Note that this work is on top of #314 (and includes its commits): it would be best to merge #296 first and this second as intended.

This should be the last preparatory PR, the next one will introduce a new version in the build.

@xuwei-k what do you think of this and #314?