### PR TITLE
use latest version of scala-xml for scala 2 > 11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,7 +150,7 @@ libraryDependencies ++= {
 
 libraryDependencies ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, scalaMajor)) if scalaMajor == 11 =>
+    case Some((2, 11)) =>
       Seq("org.scala-lang.modules" %% "scala-xml" % "1.3.0")
     case Some((2, scalaMajor)) if scalaMajor >= 12 =>
       Seq("org.scala-lang.modules" %% "scala-xml" % "2.0.1")

--- a/build.sbt
+++ b/build.sbt
@@ -150,8 +150,10 @@ libraryDependencies ++= {
 
 libraryDependencies ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+    case Some((2, scalaMajor)) if scalaMajor == 11 =>
       Seq("org.scala-lang.modules" %% "scala-xml" % "1.3.0")
+    case Some((2, scalaMajor)) if scalaMajor >= 12 =>
+      Seq("org.scala-lang.modules" %% "scala-xml" % "2.0.1")
     case _ =>
       Nil
   }


### PR DESCRIPTION
Update the scala xml version for Scala 2.x versions > 11. Recent users of the scala xml library should have migrated onto v2 by now. If squeryl is also a dependency of the project then sbt > 1.5 is raising an eviction error due to potential binary incompatibility.

```
[error] java.lang.RuntimeException: found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error] 	* org.scala-lang.modules:scala-xml_2.13:2.0.0 (early-semver) is selected over 1.2.0
[error] 	    +- com.myorg:myproject:1.0.0          (depends on 2.0.0)
[error] 	    +- org.squeryl:squeryl_2.13:0.9.17                    (depends on 1.2.0)
```