### PR TITLE
Support for SQL arrays in H2

### DIFF
--- a/src/main/scala/org/squeryl/adapters/H2Adapter.scala
+++ b/src/main/scala/org/squeryl/adapters/H2Adapter.scala
@@ -52,4 +52,9 @@ class H2Adapter extends DatabaseAdapter {
     e.getErrorCode == 42102
 
   override def supportsCommonTableExpressions = false
+
+  override def intArrayTypeDeclaration: String = "ARRAY"
+  override def longArrayTypeDeclaration: String = "ARRAY"
+  override def doubleArrayTypeDeclaration: String = "ARRAY"
+  override def stringArrayTypeDeclaration: String = "ARRAY"
 }

--- a/src/test/scala/org/squeryl/h2/H2Tests.scala
+++ b/src/test/scala/org/squeryl/h2/H2Tests.scala
@@ -1,11 +1,11 @@
 package org.squeryl.h2
 
 import org.squeryl.test._
-
 import org.squeryl.framework.DBConnector
 import org.squeryl.adapters.H2Adapter
-
+import org.squeryl.test.arrays.PrimitiveArrayTest
 import org.squeryl.{AbstractSession, Session}
+
 import java.sql.Connection
 
 /*
@@ -64,6 +64,8 @@ class H2_ConnectionClosing extends ConnectionClosingTest with H2_Connection {
 class H2_LogicalBooleanObjTests extends LogicalBooleanObjTests with H2_Connection
 
 class H2_CommonTableExpressions extends schooldb.CommonTableExpressions with H2_Connection
+
+class H2_ArrayTests extends PrimitiveArrayTest with H2_Connection
 
 /*
  * Lazy


### PR DESCRIPTION
This is a small PR that fixes the SQL array support in `H2Adapter`.