### PR TITLE
H2 2.x use VARBINARY instead of BINARY(1)

### DIFF
--- a/src/main/scala/org/squeryl/adapters/H2Adapter.scala
+++ b/src/main/scala/org/squeryl/adapters/H2Adapter.scala
@@ -22,6 +22,7 @@ import org.squeryl.internals.{FieldMetaData, DatabaseAdapter}
 class H2Adapter extends DatabaseAdapter {
 
   override def uuidTypeDeclaration = "uuid"
+  override def binaryTypeDeclaration = "varbinary"
   override def isFullOuterJoinSupported = false
 
   override def writeColumnDeclaration(fmd: FieldMetaData, isPrimaryKey: Boolean, schema: Schema): String = {


### PR DESCRIPTION
In H2 2.x BINARY now works like BINARY(1).
In H2 1.x BINARY is alias for VARBINARY

Use VARBINARY that works more like BINARY was in H2 1.x

It fixes the failed test "blobTest"
