### PR TITLE
H2 2.x requires explicit ARRAY type declaration

### DIFF
--- a/src/main/scala/org/squeryl/adapters/H2Adapter.scala
+++ b/src/main/scala/org/squeryl/adapters/H2Adapter.scala
@@ -53,8 +53,8 @@ class H2Adapter extends DatabaseAdapter {
 
   override def supportsCommonTableExpressions = false
 
-  override def intArrayTypeDeclaration: String = "ARRAY"
-  override def longArrayTypeDeclaration: String = "ARRAY"
-  override def doubleArrayTypeDeclaration: String = "ARRAY"
-  override def stringArrayTypeDeclaration: String = "ARRAY"
+  override def intArrayTypeDeclaration: String = s"$intTypeDeclaration ARRAY"
+  override def longArrayTypeDeclaration: String = s"$longTypeDeclaration ARRAY"
+  override def doubleArrayTypeDeclaration: String = s"$doubleTypeDeclaration ARRAY"
+  override def stringArrayTypeDeclaration: String = s"$stringTypeDeclaration ARRAY"
 }


### PR DESCRIPTION
Starting from H2 2.x ARRAY type should be explicitly defined:
int ARRAY
long ARRAY
...

It fixes problems with tests H2_ArrayTests