### PR TITLE
Add quoteIdentifier to H2. Remove quoteIdentifier from CAST expressions.

### DIFF
--- a/src/main/scala/org/squeryl/adapters/H2Adapter.scala
+++ b/src/main/scala/org/squeryl/adapters/H2Adapter.scala
@@ -24,16 +24,18 @@ class H2Adapter extends DatabaseAdapter {
   override def uuidTypeDeclaration = "uuid"
   override def isFullOuterJoinSupported = false
 
+  override def quoteIdentifier(s: String): String = "\"" + s.replace("\"", "\"\"") + "\""
+
   override def writeColumnDeclaration(fmd: FieldMetaData, isPrimaryKey: Boolean, schema: Schema): String = {
 
-    var res = "  " + fmd.columnName + " " + databaseTypeFor(fmd)
+    var res = s"  ${quoteName(fmd.columnName)} ${databaseTypeFor(fmd)}"
 
     for (d <- fmd.defaultValue) {
       val v = convertToJdbcValue(d.value.asInstanceOf[AnyRef])
       if (v.isInstanceOf[String])
-        res += " default '" + v + "'"
+        res += s" default '$v'"
       else
-        res += " default " + v
+        res += s" default $v"
     }
 
     if (!fmd.isOption)

--- a/src/main/scala/org/squeryl/dsl/ast/CastExpressionNode.scala
+++ b/src/main/scala/org/squeryl/dsl/ast/CastExpressionNode.scala
@@ -3,13 +3,13 @@ package org.squeryl.dsl.ast
 import org.squeryl.internals.*
 
 class CastExpressionNode(expr: ExpressionNode, typ: String) extends ExpressionNode {
-  override def doWrite(sw: StatementWriter) = {
+  override def doWrite(sw: StatementWriter): Unit = {
     sw.write("cast(")
     expr.write(sw)
-    sw.write(" as " + sw.databaseAdapter.quoteIdentifier(typ) + ")")
+    sw.write(s" as $typ)")
   }
 
-  override def children = List(expr)
+  override def children: List[ExpressionNode] = List(expr)
 
-  override def toString = "'CastExpressionNode:" + expr.toString + "::" + typ
+  override def toString: String = s"'CastExpressionNode:$expr::$typ"
 }

--- a/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
+++ b/src/main/scala/org/squeryl/internals/DatabaseAdapter.scala
@@ -666,7 +666,7 @@ trait DatabaseAdapter {
         case Some(dbType) if col.explicitDbTypeCast => {
           sw.write("cast(")
           v.write(sw)
-          sw.write(s" as ${sw.quoteName(dbType)})")
+          sw.write(s" as $dbType)")
         }
         case _ => {
           sw.write("(")

--- a/src/test/scala/org/squeryl/test/schooldb/SchoolDb.scala
+++ b/src/test/scala/org/squeryl/test/schooldb/SchoolDb.scala
@@ -279,22 +279,16 @@ class SchoolDb extends Schema {
   override def callbacks: Seq[LifecycleEvent] = Seq(
     // We'll change the gender of z1 z2 student
     beforeInsert[Student]()
-      map (s => {
+      .map (s => {
         if (s.name == "z1" && s.lastName == "z2") { val s2 = studentTransform(s); transformedStudents.append(s2); s2 }
         else s
       }),
-    beforeInsert[Person]()
-      map (p => { beforeInsertsOfPerson.append(p); p }),
-    beforeInsert[Professor]()
-      call (beforeInsertsOfProfessor.append(_)),
-    beforeInsert[KeyedEntity[?]]()
-      call (beforeInsertsOfKeyedEntity.append(_)),
-    afterSelect[Student]()
-      call (afterSelectsOfStudent.append(_)),
-    afterInsert[Professor]()
-      call (afterInsertsOfProfessor.append(_)),
-    afterInsert(schools)
-      call (afterInsertsOfSchool.append(_)),
+    beforeInsert[Person]() map (p => { beforeInsertsOfPerson.append(p); p }),
+    beforeInsert[Professor]() call (beforeInsertsOfProfessor.append(_)),
+    beforeInsert[KeyedEntity[?]]() call (beforeInsertsOfKeyedEntity.append(_)),
+    afterSelect[Student]() call (afterSelectsOfStudent.append(_)),
+    afterInsert[Professor]() call (afterInsertsOfProfessor.append(_)),
+    afterInsert(schools) call (afterInsertsOfSchool.append(_)),
     beforeDelete(schools) call (beforeDeleteOfSchool.append(_)),
     afterDelete(schools) call (afterDeleteOfSchool.append(_)),
     factoryFor(professors) is {
@@ -547,8 +541,10 @@ abstract class SchoolDbTestRun extends SchoolDbTestBase {
   }
 
   test("assertColumnNameChangeWithDeclareSyntax") {
-    val st = Session.currentSession.connection.createStatement()
-    st.execute("select the_Last_Name from t_professor")
+    val session = Session.currentSession
+    val adapter = session.databaseAdapter
+    val st = session.connection.createStatement()
+    st.execute(s"select ${adapter.quoteName("the_last_name")} from ${adapter.quoteName("T_Professor")}")
     // this should not blow up...
   }
 


### PR DESCRIPTION
# Add quoteIdentifier to H2
After migrating to H2 2.x set of tests failed due to use of new keywords as identifier names.
It's better to enable quoteIdentifier for H2 as it enabled in other database adapters.

# Remove quoteIdentifier from CAST
SQL doesn't require quoting for types used in CAST. 
Some databases doesn't support quoted types (like H2).
So quoting of types for CAST was disabled.

# Breaking changes
After enabling quoting in H2, manually written raw SQL may fail due to registry problems.
If you don't need quoting, it's recommended to create your own adapter by inheriting H2Adapter and override quoteIdentifier.

